### PR TITLE
feat: Add GitHub Actions workflow for automated npm publishing

### DIFF
--- a/.github/scripts/publish/determine-workflow-path.sh
+++ b/.github/scripts/publish/determine-workflow-path.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+set -e
+
+EVENT_NAME="$1"
+INPUT_VERSION_BUMP="$2"
+INPUT_NPM_TAG="$3"
+
+WORKFLOW_PATH="unknown"
+SHOULD_BUILD="false"
+VERSION_BUMP="patch"
+NPM_TAG=""
+
+if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+  echo "🔵 Manual workflow trigger detected"
+  WORKFLOW_PATH="manual"
+  SHOULD_BUILD="true"
+  VERSION_BUMP="$INPUT_VERSION_BUMP"
+  NPM_TAG="$INPUT_NPM_TAG"
+
+elif [[ "$EVENT_NAME" == "push" ]]; then
+  COMMIT_MSG=$(git log -1 --pretty=%B)
+  if [[ "$COMMIT_MSG" == *"MINOR"* || "$COMMIT_MSG" == *"MAJOR"* ]]; then
+    echo "🟢 Version bump commit detected!"
+    WORKFLOW_PATH="version-bump"
+    SHOULD_BUILD="true"
+
+    if [[ "$COMMIT_MSG" == *"MINOR"* ]]; then
+      echo "Minor version bump"
+      VERSION_BUMP="minor"
+    elif [[ "$COMMIT_MSG" == *"MAJOR"* ]]; then
+      echo "Major version bump"
+      VERSION_BUMP="major"
+    fi
+
+  elif git diff --name-only HEAD^ HEAD | grep -v "\.test\." | grep -q -E "(^\.browserslistrc$|^babel\.config\.|^src/)"; then
+    echo "🟠 Relevant file changes detected"
+    WORKFLOW_PATH="file-changes"
+    SHOULD_BUILD="true"
+
+  else
+    echo "⚪ No publishing-relevant changes detected"
+    WORKFLOW_PATH="skip"
+  fi
+fi
+
+echo "workflow-path=$WORKFLOW_PATH" >> $GITHUB_OUTPUT
+echo "should-build=$SHOULD_BUILD" >> $GITHUB_OUTPUT
+echo "version-bump=$VERSION_BUMP" >> $GITHUB_OUTPUT
+echo "npm-tag=$NPM_TAG" >> $GITHUB_OUTPUT
+
+echo "==========================================="
+echo "Workflow Path: $WORKFLOW_PATH"
+echo "Should Build: $SHOULD_BUILD"
+echo "Version Bump: $VERSION_BUMP"
+echo "NPM Tag: ${NPM_TAG:-<auto-detect>}"
+echo "==========================================="

--- a/.github/scripts/publish/determine-workflow-path.sh
+++ b/.github/scripts/publish/determine-workflow-path.sh
@@ -25,7 +25,7 @@ elif [[ "$EVENT_NAME" == "push" ]]; then
     echo "🟢 Version bump commit detected!"
     WORKFLOW_PATH="version-bump"
     SHOULD_BUILD="true"
-    
+
     if [[ "$COMMIT_MSG" == *"#minor"* ]]; then
       echo "Minor version bump"
       VERSION_BUMP="minor"

--- a/.github/scripts/publish/determine-workflow-path.sh
+++ b/.github/scripts/publish/determine-workflow-path.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 set -e
 
+# Arguments
 EVENT_NAME="$1"
 INPUT_VERSION_BUMP="$2"
 INPUT_NPM_TAG="$3"
 
+# Default values
 WORKFLOW_PATH="unknown"
 SHOULD_BUILD="false"
 VERSION_BUMP="patch"
@@ -19,15 +21,15 @@ if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
 
 elif [[ "$EVENT_NAME" == "push" ]]; then
   COMMIT_MSG=$(git log -1 --pretty=%B)
-  if [[ "$COMMIT_MSG" == *"MINOR"* || "$COMMIT_MSG" == *"MAJOR"* ]]; then
+  if [[ "$COMMIT_MSG" == *"#minor"* || "$COMMIT_MSG" == *"#major"* ]]; then
     echo "🟢 Version bump commit detected!"
     WORKFLOW_PATH="version-bump"
     SHOULD_BUILD="true"
-
-    if [[ "$COMMIT_MSG" == *"MINOR"* ]]; then
+    
+    if [[ "$COMMIT_MSG" == *"#minor"* ]]; then
       echo "Minor version bump"
       VERSION_BUMP="minor"
-    elif [[ "$COMMIT_MSG" == *"MAJOR"* ]]; then
+    elif [[ "$COMMIT_MSG" == *"#major"* ]]; then
       echo "Major version bump"
       VERSION_BUMP="major"
     fi

--- a/.github/scripts/publish/publish-to-npm.sh
+++ b/.github/scripts/publish/publish-to-npm.sh
@@ -41,7 +41,7 @@ if [[ "$DRY_RUN" == "true" ]]; then
 fi
 
 # Temporary guards for testing
-# PUBLISH_ARGS="$PUBLISH_ARGS --dry-run"
-# echo "⚠️ TEST MODE: Force using --dry-run flag. Remove before merging to main! ⚠️"
+PUBLISH_ARGS="$PUBLISH_ARGS --dry-run"
+echo "⚠️ TEST MODE: Force using --dry-run flag. Remove before merging to main! ⚠️"
 
 npm publish $PUBLISH_ARGS

--- a/.github/scripts/publish/publish-to-npm.sh
+++ b/.github/scripts/publish/publish-to-npm.sh
@@ -19,7 +19,9 @@ if [[ -n "$NPM_TAG" && "$USING_DEFAULT_TAG" == "false" ]]; then
   PUBLISH_ARGS="$PUBLISH_ARGS --tag $DIST_TAG"
   echo "Publishing v$NEW_VERSION with custom tag '$DIST_TAG'"
 elif [[ "$BRANCH_NAME" == "main" ]]; then
-  echo "Publishing v$NEW_VERSION from main -> using default 'latest' tag"
+  DIST_TAG="beta"
+  PUBLISH_ARGS="$PUBLISH_ARGS --tag $DIST_TAG"
+  echo "Publishing v$NEW_VERSION from main -> using 'beta' tag"
 elif [[ "$BRANCH_NAME" =~ release/v([0-9]+) ]]; then
   MAJOR_VERSION="${BASH_REMATCH[1]}"
   DIST_TAG="${MAJOR_VERSION}x"

--- a/.github/scripts/publish/publish-to-npm.sh
+++ b/.github/scripts/publish/publish-to-npm.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -e
+
+BRANCH_NAME="$1"
+WORKFLOW_PATH="$2"
+NPM_TAG="$3"
+DRY_RUN="$4"
+
+NEW_VERSION=$(npm pkg get version | tr -d \")
+PUBLISH_ARGS="--access public"
+
+USING_DEFAULT_TAG=false
+if [[ "$WORKFLOW_PATH" == "manual" && "$NPM_TAG" == "beta" ]]; then
+  USING_DEFAULT_TAG=true
+fi
+
+if [[ -n "$NPM_TAG" && "$USING_DEFAULT_TAG" == "false" ]]; then
+  DIST_TAG="$NPM_TAG"
+  PUBLISH_ARGS="$PUBLISH_ARGS --tag $DIST_TAG"
+  echo "Publishing v$NEW_VERSION with custom tag '$DIST_TAG'"
+elif [[ "$BRANCH_NAME" == "main" ]]; then
+  echo "Publishing v$NEW_VERSION from main -> using default 'latest' tag"
+elif [[ "$BRANCH_NAME" =~ release/v([0-9]+) ]]; then
+  MAJOR_VERSION="${BASH_REMATCH[1]}"
+  DIST_TAG="${MAJOR_VERSION}x"
+  PUBLISH_ARGS="$PUBLISH_ARGS --tag $DIST_TAG"
+  echo "Publishing v$NEW_VERSION from $BRANCH_NAME -> using tag '$DIST_TAG'"
+else
+  if [[ "$WORKFLOW_PATH" == "manual" && "$USING_DEFAULT_TAG" == "true" ]]; then
+    DIST_TAG="beta"
+    PUBLISH_ARGS="$PUBLISH_ARGS --tag $DIST_TAG"
+    echo "⚠️ WARNING: Publishing from non-standard branch '$BRANCH_NAME' with default 'beta' tag"
+  else
+    echo "Branch $BRANCH_NAME doesn't match expected patterns, using default publishing"
+  fi
+fi
+
+if [[ "$DRY_RUN" == "true" ]]; then
+  PUBLISH_ARGS="$PUBLISH_ARGS --dry-run"
+  echo "DRY RUN MODE - No actual publishing will occur"
+fi
+
+# Temporary guards for testing
+# PUBLISH_ARGS="$PUBLISH_ARGS --dry-run"
+# echo "⚠️ TEST MODE: Force using --dry-run flag. Remove before merging to main! ⚠️"
+
+npm publish $PUBLISH_ARGS

--- a/.github/scripts/publish/publish-to-npm.sh
+++ b/.github/scripts/publish/publish-to-npm.sh
@@ -41,7 +41,7 @@ if [[ "$DRY_RUN" == "true" ]]; then
 fi
 
 # Temporary guards for testing
-PUBLISH_ARGS="$PUBLISH_ARGS --dry-run"
-echo "⚠️ TEST MODE: Force using --dry-run flag. Remove before merging to main! ⚠️"
+# PUBLISH_ARGS="$PUBLISH_ARGS --dry-run"
+# echo "⚠️ TEST MODE: Force using --dry-run flag. Remove before merging to main! ⚠️"
 
 npm publish $PUBLISH_ARGS

--- a/.github/scripts/publish/version-bump-details.sh
+++ b/.github/scripts/publish/version-bump-details.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -e
+
+BRANCH_NAME="$1"
+VERSION_TYPE="$2"
+
+echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
+
+if [[ "$BRANCH_NAME" =~ release/v([0-9]+) ]]; then
+  MAJOR_VERSION="${BASH_REMATCH[1]}"
+
+  if [[ "$VERSION_TYPE" == "major" ]]; then
+    echo "::error::⛔ MAJOR VERSION BUMP NOT ALLOWED ON RELEASE BRANCH"
+    echo "::error::Branch release/v${MAJOR_VERSION} is locked to major version ${MAJOR_VERSION}."
+    echo "::error::To publish a new major version, create a new branch named release/v$((MAJOR_VERSION+1))."
+    exit 1
+  fi
+
+  CURRENT_VERSION=$(npm pkg get version | tr -d \")
+  CURRENT_MAJOR=$(echo $CURRENT_VERSION | cut -d. -f1)
+
+  if [[ "$CURRENT_MAJOR" != "$MAJOR_VERSION" ]]; then
+    echo "::error::🚫 Major version mismatch: package.json version $CURRENT_VERSION does not match release/v${MAJOR_VERSION} branch."
+    echo "::error::Please update the package.json manually to match major version ${MAJOR_VERSION}, or rename the branch if you intended a different major."
+    exit 1
+  fi
+fi
+
+echo "VERSION_TYPE=$VERSION_TYPE" >> $GITHUB_ENV

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,9 +13,9 @@ on:
           - minor
           - major
       npm_tag:
-        description: 'Custom npm dist-tag (ALWAYS specify for non-standard branches to avoid overwriting latest)'
+        description: 'Custom npm tag (only needed for non-standard branches; release branches will use their major version tag automatically)'
         required: false
-        default: 'dev'
+        default: 'beta'
         type: string
       dry_run:
         description: 'Dry run (no actual publishing)'
@@ -43,73 +43,16 @@ jobs:
       workflow-path: ${{ steps.check-path.outputs.workflow-path }}
       version-bump: ${{ steps.check-path.outputs.version-bump }}
       npm-tag: ${{ steps.check-path.outputs.npm-tag }}
-
+      
     steps:
       - name: Check out code
         uses: actions/checkout@v4
         with:
           fetch-depth: 2
-
+      
       - name: Determine workflow path
         id: check-path
-        run: |
-          # Default values
-          WORKFLOW_PATH="unknown"
-          SHOULD_BUILD="false"
-          VERSION_BUMP="patch"
-          NPM_TAG=""
-
-          # Manual workflow dispatch
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            echo "🔵 Manual workflow trigger detected"
-            WORKFLOW_PATH="manual"
-            SHOULD_BUILD="true"
-            VERSION_BUMP="${{ github.event.inputs.version_bump }}"
-            NPM_TAG="${{ github.event.inputs.npm_tag }}"
-
-          # Automatic triggers from push events
-          elif [[ "${{ github.event_name }}" == "push" ]]; then
-            # Check for version bump commit first
-            COMMIT_MSG=$(git log -1 --pretty=%B)
-            if [[ "$COMMIT_MSG" == *"MINOR"* || "$COMMIT_MSG" == *"MAJOR"* ]]; then
-              echo "🟢 Version bump commit detected!"
-              WORKFLOW_PATH="version-bump"
-              SHOULD_BUILD="true"
-
-              if [[ "$COMMIT_MSG" == *"MINOR"* ]]; then
-                echo "Minor version bump"
-                VERSION_BUMP="minor"
-              elif [[ "$COMMIT_MSG" == *"MAJOR"* ]]; then
-                echo "Major version bump"
-                VERSION_BUMP="major"
-              fi
-
-            # Next, check if any relevant files changed (matching the original path filters)
-            elif git diff --name-only HEAD^ HEAD | grep -v "\.test\." | grep -q -E "(^\.browserslistrc$|^babel\.config\.|^src/)"; then
-              echo "🟠 Relevant file changes detected"
-              WORKFLOW_PATH="file-changes"
-              SHOULD_BUILD="true"
-
-            # No relevant changes - skip publishing
-            else
-              echo "⚪ No publishing-relevant changes detected"
-              WORKFLOW_PATH="skip"
-            fi
-          fi
-
-          # Set outputs for downstream jobs
-          echo "workflow-path=$WORKFLOW_PATH" >> $GITHUB_OUTPUT
-          echo "should-build=$SHOULD_BUILD" >> $GITHUB_OUTPUT
-          echo "version-bump=$VERSION_BUMP" >> $GITHUB_OUTPUT
-          echo "npm-tag=$NPM_TAG" >> $GITHUB_OUTPUT
-
-          # Summary for logs
-          echo "==========================================="
-          echo "Workflow Path: $WORKFLOW_PATH"
-          echo "Should Build: $SHOULD_BUILD"
-          echo "Version Bump: $VERSION_BUMP"
-          echo "NPM Tag: ${NPM_TAG:-<auto-detect>}"
-          echo "==========================================="
+        run: .github/scripts/publish/determine-workflow-path.sh "${{ github.event_name }}" "${{ github.event.inputs.version_bump }}" "${{ github.event.inputs.npm_tag }}"
 
   build:
     name: Build
@@ -198,36 +141,7 @@ jobs:
 
       - name: Determine version bump details
         id: version-details
-        run: |
-          BRANCH_NAME="${{ github.ref_name }}"
-          VERSION_TYPE="${{ needs.determine-path.outputs.version-bump }}"
-
-          echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
-
-          # Check for invalid version bumps on release branches
-          if [[ "$BRANCH_NAME" =~ release/v([0-9]+) ]]; then
-            MAJOR_VERSION="${BASH_REMATCH[1]}"
-
-            # Fail if a major bump was requested on a release branch
-            if [[ "$VERSION_TYPE" == "major" ]]; then
-              echo "::error::⛔ MAJOR VERSION BUMP NOT ALLOWED ON RELEASE BRANCH"
-              echo "::error::Branch release/v${MAJOR_VERSION} is locked to major version ${MAJOR_VERSION}."
-              echo "::error::To publish a new major version, create a new branch named release/v$((MAJOR_VERSION+1))."
-              exit 1
-            fi
-
-            # Set the package version to match the major version if needed
-            CURRENT_VERSION=$(npm pkg get version | tr -d \")
-            CURRENT_MAJOR=$(echo $CURRENT_VERSION | cut -d. -f1)
-
-            if [[ "$CURRENT_MAJOR" != "$MAJOR_VERSION" ]]; then
-              echo "::error::🚫 Major version mismatch: package.json version $CURRENT_VERSION does not match release/v${MAJOR_VERSION} branch."
-              echo "::error::Please update the package.json manually to match major version ${MAJOR_VERSION}, or rename the branch if you intended a different major."
-              exit 1
-            fi
-          fi
-
-          echo "VERSION_TYPE=$VERSION_TYPE" >> $GITHUB_ENV
+        run: .github/scripts/publish/version-bump-details.sh "${{ github.ref_name }}" "${{ needs.determine-path.outputs.version-bump }}"
 
       - name: Update package version
         run: |
@@ -242,45 +156,6 @@ jobs:
           git commit -am "v$NEW_VERSION [skip ci]" && git push
 
       - name: Publish to npm with appropriate dist-tag
-        run: |
-          # Fix redundant variable assignment
-          NEW_VERSION=$(npm pkg get version | tr -d \")
-          PUBLISH_ARGS="--access public"
-
-          # First priority: Check for custom tag from inputs
-          if [[ -n "${{ needs.determine-path.outputs.npm-tag }}" ]]; then
-            DIST_TAG="${{ needs.determine-path.outputs.npm-tag }}"
-            PUBLISH_ARGS="$PUBLISH_ARGS --tag $DIST_TAG"
-            echo "Publishing v$NEW_VERSION with custom tag '$DIST_TAG'"
-          # Second priority: Check for branch-specific tags
-          elif [[ "$BRANCH_NAME" == "main" ]]; then
-            echo "Publishing v$NEW_VERSION from main -> using default 'latest' tag"
-          elif [[ "$BRANCH_NAME" =~ release/v([0-9]+) ]]; then
-            MAJOR_VERSION="${BASH_REMATCH[1]}"
-            # Using Mongoose-style tag format: 1x, 2x, 3x
-            DIST_TAG="${MAJOR_VERSION}x"
-            PUBLISH_ARGS="$PUBLISH_ARGS --tag $DIST_TAG"
-            echo "Publishing v$NEW_VERSION from $BRANCH_NAME -> using tag '$DIST_TAG'"
-          else
-            # Safety check for non-standard branches
-            if [[ "${{ github.event_name }}" == "workflow_dispatch" && -z "${{ needs.determine-path.outputs.npm-tag }}" ]]; then
-              echo "⚠️ WARNING: Publishing from non-standard branch '$BRANCH_NAME' without a custom npm tag"
-              echo "⚠️ This will publish as 'latest' and may overwrite your production release"
-            fi
-            echo "Branch $BRANCH_NAME doesn't match expected patterns, using default publishing"
-          fi
-
-          # Add dry-run flag if specified (for manual workflow)
-          if [[ "${{ github.event.inputs.dry_run }}" == "true" ]]; then
-            PUBLISH_ARGS="$PUBLISH_ARGS --dry-run"
-            echo "DRY RUN MODE - No actual publishing will occur"
-          fi
-
-          # Temporary safety measure for testing
-          # PUBLISH_ARGS="$PUBLISH_ARGS --dry-run"
-          # echo "⚠️ TEST MODE: Force using --dry-run flag. Remove before merging to main! ⚠️"
-
-          # Execute npm publish with all arguments
-          npm publish $PUBLISH_ARGS
+        run: .github/scripts/publish/publish-to-npm.sh "${{ github.ref_name }}" "${{ needs.determine-path.outputs.workflow-path }}" "${{ needs.determine-path.outputs.npm-tag }}" "${{ github.event.inputs.dry_run }}"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Determine workflow path
         id: check-path
-        run: .github/scripts/publish/determine-workflow-path.sh "${{ github.event_name }}" "${{ github.event.inputs.version_bump }}" "${{ github.event.inputs.npm_tag }}"
+        run: bash .github/scripts/publish/determine-workflow-path.sh "${{ github.event_name }}" "${{ github.event.inputs.version_bump }}" "${{ github.event.inputs.npm_tag }}"
 
   build:
     name: Build
@@ -141,7 +141,7 @@ jobs:
 
       - name: Determine version bump details
         id: version-details
-        run: .github/scripts/publish/version-bump-details.sh "${{ github.ref_name }}" "${{ needs.determine-path.outputs.version-bump }}"
+        run: bash .github/scripts/publish/version-bump-details.sh "${{ github.ref_name }}" "${{ needs.determine-path.outputs.version-bump }}"
 
       - name: Update package version
         run: |
@@ -156,6 +156,6 @@ jobs:
           git commit -am "v$NEW_VERSION [skip ci]" && git push
 
       - name: Publish to npm with appropriate dist-tag
-        run: .github/scripts/publish/publish-to-npm.sh "${{ github.ref_name }}" "${{ needs.determine-path.outputs.workflow-path }}" "${{ needs.determine-path.outputs.npm-tag }}" "${{ github.event.inputs.dry_run }}"
+        run: bash .github/scripts/publish/publish-to-npm.sh "${{ github.ref_name }}" "${{ needs.determine-path.outputs.workflow-path }}" "${{ needs.determine-path.outputs.npm-tag }}" "${{ github.event.inputs.dry_run }}"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,8 +13,9 @@ on:
           - minor
           - major
       npm_tag:
-        description: 'Custom npm dist-tag (leave empty for auto-detection based on branch)'
+        description: 'Custom npm dist-tag (ALWAYS specify for non-standard branches to avoid overwriting latest)'
         required: false
+        default: 'dev'
         type: string
       dry_run:
         description: 'Dry run (no actual publishing)'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,22 +27,94 @@ on:
     branches:
       - main
       - 'release/v[0-9]*'
-    paths:
-      - '.browserslistrc'
-      - 'babel.config.*'
-      - 'src/**'
-      - '!**/*.test.*'
 
 concurrency:
-  group: publish-engine-plugin
+  group: publish-engine-plugin-${{ github.ref }}
 
 permissions:
   contents: write
   packages: write
 
 jobs:
+  determine-path:
+    name: Determine Workflow Path
+    runs-on: ubuntu-24.04
+    outputs:
+      workflow-path: ${{ steps.check-path.outputs.workflow-path }}
+      version-bump: ${{ steps.check-path.outputs.version-bump }}
+      npm-tag: ${{ steps.check-path.outputs.npm-tag }}
+      
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+      
+      - name: Determine workflow path
+        id: check-path
+        run: |
+          # Default values
+          WORKFLOW_PATH="unknown"
+          SHOULD_BUILD="false"
+          VERSION_BUMP="patch"
+          NPM_TAG=""
+          
+          # Manual workflow dispatch
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "🔵 Manual workflow trigger detected"
+            WORKFLOW_PATH="manual"
+            SHOULD_BUILD="true"
+            VERSION_BUMP="${{ github.event.inputs.version_bump }}"
+            NPM_TAG="${{ github.event.inputs.npm_tag }}"
+          
+          # Automatic triggers from push events
+          elif [[ "${{ github.event_name }}" == "push" ]]; then
+            # Check for version bump commit first
+            COMMIT_MSG=$(git log -1 --pretty=%B)
+            if [[ "$COMMIT_MSG" == *"MINOR"* || "$COMMIT_MSG" == *"MAJOR"* ]]; then
+              echo "🟢 Version bump commit detected!"
+              WORKFLOW_PATH="version-bump"
+              SHOULD_BUILD="true"
+              
+              if [[ "$COMMIT_MSG" == *"MINOR"* ]]; then
+                echo "Minor version bump"
+                VERSION_BUMP="minor"
+              elif [[ "$COMMIT_MSG" == *"MAJOR"* ]]; then
+                echo "Major version bump"
+                VERSION_BUMP="major"
+              fi
+              
+            # Next, check if any relevant files changed (matching the original path filters)
+            elif git diff --name-only HEAD^ HEAD | grep -v "\.test\." | grep -q -E "(^\.browserslistrc$|^babel\.config\.|^src/)"; then
+              echo "🟠 Relevant file changes detected"
+              WORKFLOW_PATH="file-changes"
+              SHOULD_BUILD="true"
+              
+            # No relevant changes - skip publishing
+            else
+              echo "⚪ No publishing-relevant changes detected"
+              WORKFLOW_PATH="skip"
+            fi
+          fi
+          
+          # Set outputs for downstream jobs
+          echo "workflow-path=$WORKFLOW_PATH" >> $GITHUB_OUTPUT
+          echo "should-build=$SHOULD_BUILD" >> $GITHUB_OUTPUT
+          echo "version-bump=$VERSION_BUMP" >> $GITHUB_OUTPUT
+          echo "npm-tag=$NPM_TAG" >> $GITHUB_OUTPUT
+          
+          # Summary for logs
+          echo "===========================================" 
+          echo "Workflow Path: $WORKFLOW_PATH"
+          echo "Should Build: $SHOULD_BUILD"
+          echo "Version Bump: $VERSION_BUMP"
+          echo "NPM Tag: ${NPM_TAG:-<auto-detect>}"
+          echo "==========================================="
+
   build:
     name: Build
+    needs: [determine-path]
+    if: needs.determine-path.outputs.workflow-path != 'skip'
     runs-on: ubuntu-24.04
 
     steps:
@@ -83,8 +155,9 @@ jobs:
 
   publish:
     name: Publish
+    needs: [determine-path, build]
+    if: needs.determine-path.outputs.workflow-path != 'skip'
     runs-on: ubuntu-24.04
-    needs: [build]
     environment: production
 
     steps:
@@ -94,19 +167,23 @@ jobs:
           fetch-depth: 2
           ref: ${{ github.ref }}
 
+      - name: Display workflow path
+        run: |
+          echo "⭐ Executing ${{ needs.determine-path.outputs.workflow-path }} workflow path"
+          echo "Version bump type: ${{ needs.determine-path.outputs.version-bump }}"
+          echo "NPM Tag: ${{ needs.determine-path.outputs.npm-tag || '<auto-detect>' }}"
+
       - name: Restore dependencies
         uses: actions/cache/restore@v4
         with:
           enableCrossOsArchive: true
-          fail-on-cache-miss: true
           key: npm-install-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
           path: node_modules
 
-      - name: Restore build
+      - name: Restore build artifacts
         uses: actions/cache/restore@v4
         with:
           enableCrossOsArchive: true
-          fail-on-cache-miss: true
           key: npm-build-${{ runner.os }}-${{ github.sha }}
           path: |
             .server
@@ -119,39 +196,25 @@ jobs:
           registry-url: https://registry.npmjs.org
           scope: '@defra'
 
-      - name: Determine version bump type
-        id: version-type
+      - name: Determine version bump details 
+        id: version-details
         run: |
-          BRANCH_NAME=${GITHUB_REF#refs/heads/}
+          BRANCH_NAME="${{ github.ref_name }}"
+          VERSION_TYPE="${{ needs.determine-path.outputs.version-bump }}"
           
-          # Check if this is a manual trigger with inputs
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            VERSION_TYPE="${{ github.event.inputs.version_bump }}"
-            echo "Manual workflow run with version bump: $VERSION_TYPE"
-            
-            # If a custom npm tag was provided, use it
-            if [[ -n "${{ github.event.inputs.npm_tag }}" ]]; then
-              CUSTOM_NPM_TAG="${{ github.event.inputs.npm_tag }}"
-              echo "Using custom npm tag: $CUSTOM_NPM_TAG"
-              echo "CUSTOM_NPM_TAG=$CUSTOM_NPM_TAG" >> $GITHUB_OUTPUT
-            fi
-          else
-            # Automatic trigger via push - use commit message logic
-            COMMIT_MSG=$(git log -1 --pretty=%B)
-            VERSION_TYPE="patch"
-            
-            # Check for MINOR or MAJOR in commit message
-            if [[ "$COMMIT_MSG" == *"MINOR"* ]]; then
-              VERSION_TYPE="minor"
-            elif [[ "$COMMIT_MSG" == *"MAJOR"* ]]; then
-              VERSION_TYPE="major"
-            fi
-          fi
+          echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
           
-          # For release branches, respect the branch naming convention
+          # Check for invalid version bumps on release branches
           if [[ "$BRANCH_NAME" =~ release/v([0-9]+) ]]; then
-            # Extract just the major version number
             MAJOR_VERSION="${BASH_REMATCH[1]}"
+            
+            # Fail if a major bump was requested on a release branch
+            if [[ "$VERSION_TYPE" == "major" ]]; then
+              echo "::error::⛔ MAJOR VERSION BUMP NOT ALLOWED ON RELEASE BRANCH"
+              echo "::error::Branch release/v${MAJOR_VERSION} is locked to major version ${MAJOR_VERSION}."
+              echo "::error::To publish a new major version, create a new branch named release/v$((MAJOR_VERSION+1))."
+              exit 1
+            fi
             
             # Set the package version to match the major version if needed
             CURRENT_VERSION=$(npm pkg get version | tr -d \")
@@ -166,11 +229,12 @@ jobs:
             fi
           fi
           
-          echo "VERSION_TYPE=$VERSION_TYPE" >> $GITHUB_OUTPUT
-          echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_OUTPUT
+          echo "VERSION_TYPE=$VERSION_TYPE" >> $GITHUB_ENV
 
       - name: Update package version
-        run: npm version ${{ steps.version-type.outputs.VERSION_TYPE }} --git-tag-version false --save
+        run: |
+          echo "Bumping version: $VERSION_TYPE"
+          npm version $VERSION_TYPE --git-tag-version false --save
 
       - name: Commit and push updates
         run: |
@@ -181,13 +245,13 @@ jobs:
 
       - name: Publish to npm with appropriate dist-tag
         run: |
-          BRANCH_NAME="${{ steps.version-type.outputs.BRANCH_NAME }}"
+          BRANCH_NAME="${BRANCH_NAME}"
           NEW_VERSION=$(npm pkg get version | tr -d \")
           PUBLISH_ARGS="--access public"
           
-          # First priority: Check for custom tag from version-type step
-          if [[ -n "${{ steps.version-type.outputs.CUSTOM_NPM_TAG }}" ]]; then
-            DIST_TAG="${{ steps.version-type.outputs.CUSTOM_NPM_TAG }}"
+          # First priority: Check for custom tag from inputs
+          if [[ -n "${{ needs.determine-path.outputs.npm-tag }}" ]]; then
+            DIST_TAG="${{ needs.determine-path.outputs.npm-tag }}"
             PUBLISH_ARGS="$PUBLISH_ARGS --tag $DIST_TAG"
             echo "Publishing v$NEW_VERSION with custom tag '$DIST_TAG'"
           # Second priority: Check for branch-specific tags
@@ -195,28 +259,24 @@ jobs:
             echo "Publishing v$NEW_VERSION from main -> using default 'latest' tag"
           elif [[ "$BRANCH_NAME" =~ release/v([0-9]+) ]]; then
             MAJOR_VERSION="${BASH_REMATCH[1]}"
-            DIST_TAG="v${MAJOR_VERSION}"
+            # Using Mongoose-style tag format: 1x, 2x, 3x
+            DIST_TAG="${MAJOR_VERSION}x"
             PUBLISH_ARGS="$PUBLISH_ARGS --tag $DIST_TAG"
             echo "Publishing v$NEW_VERSION from $BRANCH_NAME -> using tag '$DIST_TAG'"
           else
             # Safety check for non-standard branches
-            if [[ "${{ github.event_name }}" == "workflow_dispatch" && -z "${{ github.event.inputs.npm_tag }}" ]]; then
+            if [[ "${{ github.event_name }}" == "workflow_dispatch" && -z "${{ needs.determine-path.outputs.npm-tag }}" ]]; then
               echo "⚠️ WARNING: Publishing from non-standard branch '$BRANCH_NAME' without a custom npm tag"
               echo "⚠️ This will publish as 'latest' and may overwrite your production release"
             fi
             echo "Branch $BRANCH_NAME doesn't match expected patterns, using default publishing"
           fi
           
-          # Add dry-run flag if specified
+          # Add dry-run flag if specified (for manual workflow)
           if [[ "${{ github.event.inputs.dry_run }}" == "true" ]]; then
             PUBLISH_ARGS="$PUBLISH_ARGS --dry-run"
             echo "DRY RUN MODE - No actual publishing will occur"
           fi
-          
-          # TODO: REMOVE THIS LINE BEFORE MERGING TO MAIN
-          # Temporary safety measure for testing
-          PUBLISH_ARGS="$PUBLISH_ARGS --dry-run"
-          echo "⚠️ TEST MODE: Force using --dry-run flag. Remove before merging to main! ⚠️"
           
           # Execute npm publish with all arguments
           npm publish $PUBLISH_ARGS

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -220,12 +220,10 @@ jobs:
             CURRENT_VERSION=$(npm pkg get version | tr -d \")
             CURRENT_MAJOR=$(echo $CURRENT_VERSION | cut -d. -f1)
             
-            # If the major version doesn't match, reset to major.0.0
             if [[ "$CURRENT_MAJOR" != "$MAJOR_VERSION" ]]; then
-              npm version $MAJOR_VERSION.0.0 --git-tag-version false --allow-same-version
-              
-              # Override to patch since we've already set the version
-              VERSION_TYPE="patch"
+              echo "::error::🚫 Major version mismatch: package.json version $CURRENT_VERSION does not match release/v${MAJOR_VERSION} branch."
+              echo "::error::Please update the package.json manually to match major version ${MAJOR_VERSION}, or rename the branch if you intended a different major."
+              exit 1
             fi
           fi
           
@@ -245,7 +243,7 @@ jobs:
 
       - name: Publish to npm with appropriate dist-tag
         run: |
-          BRANCH_NAME="${BRANCH_NAME}"
+          # Fix redundant variable assignment
           NEW_VERSION=$(npm pkg get version | tr -d \")
           PUBLISH_ARGS="--access public"
           
@@ -277,6 +275,10 @@ jobs:
             PUBLISH_ARGS="$PUBLISH_ARGS --dry-run"
             echo "DRY RUN MODE - No actual publishing will occur"
           fi
+
+          # Temporary safety measure for testing
+          # PUBLISH_ARGS="$PUBLISH_ARGS --dry-run"
+          # echo "⚠️ TEST MODE: Force using --dry-run flag. Remove before merging to main! ⚠️"
           
           # Execute npm publish with all arguments
           npm publish $PUBLISH_ARGS

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,13 +43,13 @@ jobs:
       workflow-path: ${{ steps.check-path.outputs.workflow-path }}
       version-bump: ${{ steps.check-path.outputs.version-bump }}
       npm-tag: ${{ steps.check-path.outputs.npm-tag }}
-      
+
     steps:
       - name: Check out code
         uses: actions/checkout@v4
         with:
           fetch-depth: 2
-      
+
       - name: Determine workflow path
         id: check-path
         run: |
@@ -58,7 +58,7 @@ jobs:
           SHOULD_BUILD="false"
           VERSION_BUMP="patch"
           NPM_TAG=""
-          
+
           # Manual workflow dispatch
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             echo "🔵 Manual workflow trigger detected"
@@ -66,7 +66,7 @@ jobs:
             SHOULD_BUILD="true"
             VERSION_BUMP="${{ github.event.inputs.version_bump }}"
             NPM_TAG="${{ github.event.inputs.npm_tag }}"
-          
+
           # Automatic triggers from push events
           elif [[ "${{ github.event_name }}" == "push" ]]; then
             # Check for version bump commit first
@@ -75,7 +75,7 @@ jobs:
               echo "🟢 Version bump commit detected!"
               WORKFLOW_PATH="version-bump"
               SHOULD_BUILD="true"
-              
+
               if [[ "$COMMIT_MSG" == *"MINOR"* ]]; then
                 echo "Minor version bump"
                 VERSION_BUMP="minor"
@@ -83,28 +83,28 @@ jobs:
                 echo "Major version bump"
                 VERSION_BUMP="major"
               fi
-              
+
             # Next, check if any relevant files changed (matching the original path filters)
             elif git diff --name-only HEAD^ HEAD | grep -v "\.test\." | grep -q -E "(^\.browserslistrc$|^babel\.config\.|^src/)"; then
               echo "🟠 Relevant file changes detected"
               WORKFLOW_PATH="file-changes"
               SHOULD_BUILD="true"
-              
+
             # No relevant changes - skip publishing
             else
               echo "⚪ No publishing-relevant changes detected"
               WORKFLOW_PATH="skip"
             fi
           fi
-          
+
           # Set outputs for downstream jobs
           echo "workflow-path=$WORKFLOW_PATH" >> $GITHUB_OUTPUT
           echo "should-build=$SHOULD_BUILD" >> $GITHUB_OUTPUT
           echo "version-bump=$VERSION_BUMP" >> $GITHUB_OUTPUT
           echo "npm-tag=$NPM_TAG" >> $GITHUB_OUTPUT
-          
+
           # Summary for logs
-          echo "===========================================" 
+          echo "==========================================="
           echo "Workflow Path: $WORKFLOW_PATH"
           echo "Should Build: $SHOULD_BUILD"
           echo "Version Bump: $VERSION_BUMP"
@@ -196,18 +196,18 @@ jobs:
           registry-url: https://registry.npmjs.org
           scope: '@defra'
 
-      - name: Determine version bump details 
+      - name: Determine version bump details
         id: version-details
         run: |
           BRANCH_NAME="${{ github.ref_name }}"
           VERSION_TYPE="${{ needs.determine-path.outputs.version-bump }}"
-          
+
           echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
-          
+
           # Check for invalid version bumps on release branches
           if [[ "$BRANCH_NAME" =~ release/v([0-9]+) ]]; then
             MAJOR_VERSION="${BASH_REMATCH[1]}"
-            
+
             # Fail if a major bump was requested on a release branch
             if [[ "$VERSION_TYPE" == "major" ]]; then
               echo "::error::⛔ MAJOR VERSION BUMP NOT ALLOWED ON RELEASE BRANCH"
@@ -215,18 +215,18 @@ jobs:
               echo "::error::To publish a new major version, create a new branch named release/v$((MAJOR_VERSION+1))."
               exit 1
             fi
-            
+
             # Set the package version to match the major version if needed
             CURRENT_VERSION=$(npm pkg get version | tr -d \")
             CURRENT_MAJOR=$(echo $CURRENT_VERSION | cut -d. -f1)
-            
+
             if [[ "$CURRENT_MAJOR" != "$MAJOR_VERSION" ]]; then
               echo "::error::🚫 Major version mismatch: package.json version $CURRENT_VERSION does not match release/v${MAJOR_VERSION} branch."
               echo "::error::Please update the package.json manually to match major version ${MAJOR_VERSION}, or rename the branch if you intended a different major."
               exit 1
             fi
           fi
-          
+
           echo "VERSION_TYPE=$VERSION_TYPE" >> $GITHUB_ENV
 
       - name: Update package version
@@ -246,7 +246,7 @@ jobs:
           # Fix redundant variable assignment
           NEW_VERSION=$(npm pkg get version | tr -d \")
           PUBLISH_ARGS="--access public"
-          
+
           # First priority: Check for custom tag from inputs
           if [[ -n "${{ needs.determine-path.outputs.npm-tag }}" ]]; then
             DIST_TAG="${{ needs.determine-path.outputs.npm-tag }}"
@@ -269,7 +269,7 @@ jobs:
             fi
             echo "Branch $BRANCH_NAME doesn't match expected patterns, using default publishing"
           fi
-          
+
           # Add dry-run flag if specified (for manual workflow)
           if [[ "${{ github.event.inputs.dry_run }}" == "true" ]]; then
             PUBLISH_ARGS="$PUBLISH_ARGS --dry-run"
@@ -279,7 +279,7 @@ jobs:
           # Temporary safety measure for testing
           # PUBLISH_ARGS="$PUBLISH_ARGS --dry-run"
           # echo "⚠️ TEST MODE: Force using --dry-run flag. Remove before merging to main! ⚠️"
-          
+
           # Execute npm publish with all arguments
           npm publish $PUBLISH_ARGS
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,13 +43,13 @@ jobs:
       workflow-path: ${{ steps.check-path.outputs.workflow-path }}
       version-bump: ${{ steps.check-path.outputs.version-bump }}
       npm-tag: ${{ steps.check-path.outputs.npm-tag }}
-      
+
     steps:
       - name: Check out code
         uses: actions/checkout@v4
         with:
           fetch-depth: 2
-      
+
       - name: Determine workflow path
         id: check-path
         run: .github/scripts/publish/determine-workflow-path.sh "${{ github.event_name }}" "${{ github.event.inputs.version_bump }}" "${{ github.event.inputs.npm_tag }}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -183,18 +183,12 @@ jobs:
           BRANCH_NAME="${{ steps.version-type.outputs.BRANCH_NAME }}"
           NEW_VERSION=$(npm pkg get version | tr -d \")
           PUBLISH_ARGS="--access public"
-          IS_STANDARD_BRANCH=false
-          
-          # Determine if this is a standard branch
-          if [[ "$BRANCH_NAME" == "main" || "$BRANCH_NAME" =~ release/v([0-9]+) ]]; then
-            IS_STANDARD_BRANCH=true
-          fi
           
           # First priority: Check for custom tag from version-type step
           if [[ -n "${{ steps.version-type.outputs.CUSTOM_NPM_TAG }}" ]]; then
             DIST_TAG="${{ steps.version-type.outputs.CUSTOM_NPM_TAG }}"
             PUBLISH_ARGS="$PUBLISH_ARGS --tag $DIST_TAG"
-            echo "Publishing v$NEW_VERSION with custom tag '$DIST_TAG' (from version-type step)"
+            echo "Publishing v$NEW_VERSION with custom tag '$DIST_TAG'"
           # Second priority: Check for branch-specific tags
           elif [[ "$BRANCH_NAME" == "main" ]]; then
             echo "Publishing v$NEW_VERSION from main -> using default 'latest' tag"
@@ -206,11 +200,8 @@ jobs:
           else
             # Safety check for non-standard branches
             if [[ "${{ github.event_name }}" == "workflow_dispatch" && -z "${{ github.event.inputs.npm_tag }}" ]]; then
-              echo "⚠️ WARNING: Publishing from non-standard branch '$BRANCH_NAME' without a custom npm tag!"
-              echo "⚠️ This will publish as 'latest' and could overwrite your production release."
-              echo "⚠️ Consider canceling and re-running with a custom npm tag like 'beta' or 'dev'."
-              echo "⚠️ Waiting 10 seconds before proceeding..."
-              sleep 10
+              echo "⚠️ WARNING: Publishing from non-standard branch '$BRANCH_NAME' without a custom npm tag"
+              echo "⚠️ This will publish as 'latest' and may overwrite your production release"
             fi
             echo "Branch $BRANCH_NAME doesn't match expected patterns, using default publishing"
           fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,11 +1,31 @@
-name: Publish Engine plugin
+name: Publish Engine Plugin
 
 on:
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      version_bump:
+        description: 'Type of version bump to perform'
+        required: true
+        default: 'patch'
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+      npm_tag:
+        description: 'Custom npm dist-tag (leave empty for auto-detection based on branch)'
+        required: false
+        type: string
+      dry_run:
+        description: 'Dry run (no actual publishing)'
+        required: false
+        default: true
+        type: boolean
 
   push:
     branches:
       - main
+      - 'release/v[0-9]*'
     paths:
       - '.browserslistrc'
       - 'babel.config.*'
@@ -27,6 +47,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Cache dependencies
         uses: actions/cache@v4
@@ -68,8 +90,8 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
-          ref: main
+          fetch-depth: 2
+          ref: ${{ github.ref }}
 
       - name: Restore dependencies
         uses: actions/cache/restore@v4
@@ -96,16 +118,115 @@ jobs:
           registry-url: https://registry.npmjs.org
           scope: '@defra'
 
-      - name: Update package versions
-        run: npm version patch --git-tag-version false --save
+      - name: Determine version bump type
+        id: version-type
+        run: |
+          BRANCH_NAME=${GITHUB_REF#refs/heads/}
+          
+          # Check if this is a manual trigger with inputs
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            VERSION_TYPE="${{ github.event.inputs.version_bump }}"
+            echo "Manual workflow run with version bump: $VERSION_TYPE"
+            
+            # If a custom npm tag was provided, use it
+            if [[ -n "${{ github.event.inputs.npm_tag }}" ]]; then
+              CUSTOM_NPM_TAG="${{ github.event.inputs.npm_tag }}"
+              echo "Using custom npm tag: $CUSTOM_NPM_TAG"
+              echo "CUSTOM_NPM_TAG=$CUSTOM_NPM_TAG" >> $GITHUB_OUTPUT
+            fi
+          else
+            # Automatic trigger via push - use commit message logic
+            COMMIT_MSG=$(git log -1 --pretty=%B)
+            VERSION_TYPE="patch"
+            
+            # Check for MINOR or MAJOR in commit message
+            if [[ "$COMMIT_MSG" == *"MINOR"* ]]; then
+              VERSION_TYPE="minor"
+            elif [[ "$COMMIT_MSG" == *"MAJOR"* ]]; then
+              VERSION_TYPE="major"
+            fi
+          fi
+          
+          # For release branches, respect the branch naming convention
+          if [[ "$BRANCH_NAME" =~ release/v([0-9]+) ]]; then
+            # Extract just the major version number
+            MAJOR_VERSION="${BASH_REMATCH[1]}"
+            
+            # Set the package version to match the major version if needed
+            CURRENT_VERSION=$(npm pkg get version | tr -d \")
+            CURRENT_MAJOR=$(echo $CURRENT_VERSION | cut -d. -f1)
+            
+            # If the major version doesn't match, reset to major.0.0
+            if [[ "$CURRENT_MAJOR" != "$MAJOR_VERSION" ]]; then
+              npm version $MAJOR_VERSION.0.0 --git-tag-version false --allow-same-version
+              
+              # Override to patch since we've already set the version
+              VERSION_TYPE="patch"
+            fi
+          fi
+          
+          echo "VERSION_TYPE=$VERSION_TYPE" >> $GITHUB_OUTPUT
+          echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_OUTPUT
+
+      - name: Update package version
+        run: npm version ${{ steps.version-type.outputs.VERSION_TYPE }} --git-tag-version false --save
 
       - name: Commit and push updates
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
-          git commit -am "v$(npm pkg get version | tr -d \") [skip ci]" && git push
+          NEW_VERSION=$(npm pkg get version | tr -d \")
+          git commit -am "v$NEW_VERSION [skip ci]" && git push
 
-      - name: Publish to npm
-        run: npm publish --access public
+      - name: Publish to npm with appropriate dist-tag
+        run: |
+          BRANCH_NAME="${{ steps.version-type.outputs.BRANCH_NAME }}"
+          NEW_VERSION=$(npm pkg get version | tr -d \")
+          PUBLISH_ARGS="--access public"
+          IS_STANDARD_BRANCH=false
+          
+          # Determine if this is a standard branch
+          if [[ "$BRANCH_NAME" == "main" || "$BRANCH_NAME" =~ release/v([0-9]+) ]]; then
+            IS_STANDARD_BRANCH=true
+          fi
+          
+          # First priority: Check for custom tag from version-type step
+          if [[ -n "${{ steps.version-type.outputs.CUSTOM_NPM_TAG }}" ]]; then
+            DIST_TAG="${{ steps.version-type.outputs.CUSTOM_NPM_TAG }}"
+            PUBLISH_ARGS="$PUBLISH_ARGS --tag $DIST_TAG"
+            echo "Publishing v$NEW_VERSION with custom tag '$DIST_TAG' (from version-type step)"
+          # Second priority: Check for branch-specific tags
+          elif [[ "$BRANCH_NAME" == "main" ]]; then
+            echo "Publishing v$NEW_VERSION from main -> using default 'latest' tag"
+          elif [[ "$BRANCH_NAME" =~ release/v([0-9]+) ]]; then
+            MAJOR_VERSION="${BASH_REMATCH[1]}"
+            DIST_TAG="v${MAJOR_VERSION}"
+            PUBLISH_ARGS="$PUBLISH_ARGS --tag $DIST_TAG"
+            echo "Publishing v$NEW_VERSION from $BRANCH_NAME -> using tag '$DIST_TAG'"
+          else
+            # Safety check for non-standard branches
+            if [[ "${{ github.event_name }}" == "workflow_dispatch" && -z "${{ github.event.inputs.npm_tag }}" ]]; then
+              echo "⚠️ WARNING: Publishing from non-standard branch '$BRANCH_NAME' without a custom npm tag!"
+              echo "⚠️ This will publish as 'latest' and could overwrite your production release."
+              echo "⚠️ Consider canceling and re-running with a custom npm tag like 'beta' or 'dev'."
+              echo "⚠️ Waiting 10 seconds before proceeding..."
+              sleep 10
+            fi
+            echo "Branch $BRANCH_NAME doesn't match expected patterns, using default publishing"
+          fi
+          
+          # Add dry-run flag if specified
+          if [[ "${{ github.event.inputs.dry_run }}" == "true" ]]; then
+            PUBLISH_ARGS="$PUBLISH_ARGS --dry-run"
+            echo "DRY RUN MODE - No actual publishing will occur"
+          fi
+          
+          # TODO: REMOVE THIS LINE BEFORE MERGING TO MAIN
+          # Temporary safety measure for testing
+          PUBLISH_ARGS="$PUBLISH_ARGS --dry-run"
+          echo "⚠️ TEST MODE: Force using --dry-run flag. Remove before merging to main! ⚠️"
+          
+          # Execute npm publish with all arguments
+          npm publish $PUBLISH_ARGS
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ The following elements support [LiquidJS templates](https://liquidjs.com/):
 - Html (guidance) component **content**
 - Summary component **row** key title (check answers and repeater summary)
 
-### Template data
+### Template Data
 
 The data the templates are evaluated against is the raw answers the user has provided up to the page they're currently on.
 For example, given a YesNoField component called `TKsWbP`, the template `{{ TKsWbP }}` would render "true" or "false" depending on how the user answered the question.

--- a/README.md
+++ b/README.md
@@ -331,15 +331,15 @@ Our GitHub Actions workflow (`publish.yml`) is set up to make publishing a breez
 ### Semantic Versioning Control
 
 - **Patch Versioning**: This happens automatically whenever you merge code changes into `main` or any release branch.
-- **Minor and Major Bumps**: You can control these by making empty commits with specific keywords:
-  - Use `MINOR` for a minor version bump.
-  - Use `MAJOR` for a major version bump.
+- **Minor and Major Bumps**: You can control these by making empty commits with specific hashtags:
+  - Use `#minor` for a minor version bump.
+  - Use `#major` for a major version bump.
 
 **Example Commands**:
 
 ```bash
-git commit --allow-empty -m "chore(release): MINOR" # Minor bump
-git commit --allow-empty -m "chore(release): MAJOR" # Major bump
+git commit --allow-empty -m "chore(release): #minor" # Minor bump
+git commit --allow-empty -m "chore(release): #major" # Major bump
 ```
 
 ### Major-Version Release Branches

--- a/README.md
+++ b/README.md
@@ -4,6 +4,33 @@ The `@defra/forms-engine-plugin` is a [plugin](https://hapi.dev/tutorials/plugin
 
 It is designed to be embedded in the frontend of a digital service and provide a convenient, configuration driven approach to building forms that are aligned to [GDS Design System](https://design-system.service.gov.uk/) guidelines.
 
+## Table of Contents
+
+- [Installation](#installation)
+- [Dependencies](#dependencies)
+- [Setup](#setup)
+  - [Form Config](#form-config)
+  - [Static Assets and Styles](#static-assets-and-styles)
+- [Example](#example)
+- [Environment Variables](#environment-variables)
+- [Options](#options)
+  - [Services](#services)
+  - [Custom Controllers](#custom-controllers)
+  - [Custom Filters](#custom-filters)
+  - [Custom Cache](#custom-cache)
+- [Exemplar](#exemplar)
+- [Templates](#templates)
+  - [Template Data](#template-data)
+  - [Liquid Filters](#liquid-filters)
+  - [Examples](#examples)
+- [Templates and Views: Extending the Default Layout](#templates-and-views-extending-the-default-layout)
+- [Publishing the Package](#publishing-the-package)
+  - [Semantic Versioning Control](#semantic-versioning-control)
+  - [Major-Version Release Branches](#major-version-release-branches)
+  - [Manual Workflow Triggers](#manual-workflow-triggers)
+  - [Workflow Triggers](#workflow-triggers)
+  - [Safety and Consistency](#safety-and-consistency)
+
 ## Installation
 
 `npm install @defra/forms-engine-plugin --save`
@@ -296,3 +323,42 @@ The `forms-engine-plugin` path to add can be imported from:
 Which can then be appended to the `node_modules` path `node_modules/@defra/forms-engine`.
 
 The main template layout is `govuk-frontend`'s `template.njk` file, this also needs to be added to the `path`s that nunjucks can look in.
+
+## Publishing the Package
+
+Our GitHub Actions workflow (`publish.yml`) is set up to make publishing a breeze, using semantic versioning and a variety of release strategies. Here's how you can make the most of it:
+
+### Semantic Versioning Control
+
+- **Patch Versioning**: This happens automatically whenever you merge code changes into `main` or any release branch.
+- **Minor and Major Bumps**: You can control these by making empty commits with specific keywords:
+  - Use `MINOR` for a minor version bump.
+  - Use `MAJOR` for a major version bump.
+
+**Example Commands**:
+```bash
+git commit --allow-empty -m "chore(release): MINOR" # Minor bump
+git commit --allow-empty -m "chore(release): MAJOR" # Major bump
+```
+
+### Major-Version Release Branches
+
+- **Branch Naming**: Stick to `release/vX` (like `release/v1`, `release/v2`).
+- **Independent Versioning**: Each branch has its own versioning and publishes to npm with a unique dist-tag (like `2x` for `release/v2`).
+
+### Manual Workflow Triggers
+
+- **Customizable Options**: You can choose the type of version bump, specify custom npm tags, and use dry run mode for testing. Dry-run is enabled by default.
+- **Special Releases**: Perfect for beta releases or when you need to publish outside the usual process.
+
+### Workflow Triggers
+
+1. **Standard Development Flow**: Merging PRs to `main` automatically triggers a patch bump and publishes with the `latest` tag.
+2. **Backporting**: Cherry-pick fixes to release branches for patch bumps with specific tags (like `2x`).
+3. **Version Bumps**: Use empty commits for minor or major bumps.
+4. **Manual Releases**: Trigger these manually for special cases like beta or release candidates.
+
+### Safety and Consistency
+
+- **Build Process**: Every publishing scenario includes a full build to ensure everything is in top shape, except for files like tests and lint rules.
+- **Tagging Safety**: We prevent overwriting the `latest` tag by enforcing custom tags for non-standard branches. The default is set to `dev`.

--- a/README.md
+++ b/README.md
@@ -336,6 +336,7 @@ Our GitHub Actions workflow (`publish.yml`) is set up to make publishing a breez
   - Use `MAJOR` for a major version bump.
 
 **Example Commands**:
+
 ```bash
 git commit --allow-empty -m "chore(release): MINOR" # Minor bump
 git commit --allow-empty -m "chore(release): MAJOR" # Major bump

--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ git commit --allow-empty -m "chore(release): #major" # Major bump
 
 ### Workflow Triggers
 
-1. **Standard Development Flow**: Merging PRs to `main` automatically triggers a patch bump and publishes with the `latest` tag.
+1. **Standard Development Flow**: Merging PRs to `main` automatically triggers a patch bump and publishes with the `beta` tag.
 2. **Backporting**: Cherry-pick fixes to release branches for patch bumps with specific tags (like `2x`).
 3. **Version Bumps**: Use empty commits for minor or major bumps.
 4. **Manual Releases**: Trigger these manually for special cases like beta or release candidates.
@@ -362,4 +362,4 @@ git commit --allow-empty -m "chore(release): #major" # Major bump
 ### Safety and Consistency
 
 - **Build Process**: Every publishing scenario includes a full build to ensure everything is in top shape, except for files like tests and lint rules.
-- **Tagging Safety**: We prevent overwriting the `latest` tag by enforcing custom tags for non-standard branches. The default is set to `dev`.
+- **Tagging Safety**: We prevent overwriting the `beta` tag by enforcing custom tags for non-standard branches. The default is set to `beta`. For release branches, the tag will be picked up from the release branch itself.


### PR DESCRIPTION
## Description

This PR introduces enhancements to our GitHub Actions publishing workflow (`publish.yml`) to support:

- **Semantic versioning control** via commit messages.
- **Multiple major-version release branches** (`release/v1`, `release/v2`, etc.) with dedicated npm dist-tags.
- **Manual workflow triggers** with flexible publishing options.

## **Why are we doing this?**

We want to:

- Clearly manage multiple major versions of our package simultaneously.
- Allow easy backporting/ cherry-picking of fixes and features to older major versions without affecting the latest release.
- Provide explicit control over semantic version bumps (patch, minor, major) directly from commit messages.
- Enable on-demand publishing with configurable options for special cases via the workflow.

## **What's changing?**

### 1. **Automatic Patch Versioning for Regular Code Changes**

When PRs with file changes are merged to `main` or a release branch:
- The workflow automatically detects relevant file changes
- It performs a build and then publishes a patch version bump
- This happens without requiring any special commit messages

### 2. **Semantic Versioning via Empty Commits**

We can explicitly control the type of version bump by creating an empty commit with the keywords `#minor` or `#major`:

- Default (no keyword): **Patch** (`1.0.0` → `1.0.1`)
- Include `#minor`: **Minor** (`1.0.0` → `1.1.0`)
- Include `#major`: **Major** (`1.0.0` → `2.0.0`)

**E.g:**

```bash
git commit --allow-empty -m "chore(release): #minor" # Minor bump
git commit --allow-empty -m "chore(release): #major" # Major bump
```

### 3. **Major-Version Release Branches**

We can now support long-lived release branches for each major version:

- Branch naming: `release/v1`, `release/v2`, etc.
- Each branch maintains its own semantic versioning independently.
- Each branch publishes to npm with a dedicated dist-tag, ensuring older versions don't overwrite the default `latest` tag.

**Example:**

- `main` branch publishes as `latest` (e.g., `3.0.0`, `3.1.0`, etc.)
- `release/v2` branch publishes as `2x` (e.g., `2.0.0`, `2.0.1`, `2.1.0`, etc.)
- Users can install specific major versions easily:
  ```bash
  npm install @defra/forms-engine-plugin # latest from main
  npm install @defra/forms-engine-plugin@2x # latest from release/v2
  ```

### 4. **Manual Workflow Trigger**

We've added a manual workflow trigger with configurable options:

- **Version bump type**: Explicitly choose patch, minor, or major
- **Custom npm tag**: Always specify a custom tag when publishing from non-standard branches- defaults is `beta`. You don't have to specific a tag if it's a release branch as it will pick it up from there.
- **Dry run mode**: Test the publishing process without actually publishing- this is `true` by default.

This allows for special publishing scenarios like beta releases, or when we need to publish outside the normal merge process.

## **How does this workflow trigger?**

The workflow runs in three ways:

### 1. Standard Development Flow (File Changes)

**When PR is merged to main:**
```
PR with code changes → main → build → patch bump → publish with "latest" tag
```

**Example:**
- You develop a bug fix on a feature branch
- Create a PR targeting `main`
- After approval, you merge the PR
- The workflow builds and publishes version 1.0.1 with the `beta` tag
- Users get this version when they run `npm install @defra/forms-engine-plugin`

### 2. Backporting to Release Branches

**Cherry-pick commits to release branches:**
```
Cherry-pick bug fix → release/v2 → build → patch bump → publish with "2x" tag
```

**Example:**
- We have a critical bug fix in `main` (version 3.0.0)
- You cherry-pick the fix to `release/v2` to support users of the plugin that are using one of the stable release branches:
  ```bash
  git checkout release/v2
  git cherry-pick abc123def  # Commit hash from main
  git push origin release/v2
  ```
- The workflow builds and publishes version 2.0.1 with the `2x` tag
- Users on version 2 get the fix with `npm install @defra/forms-engine-plugin@2x`

### 3. Version Bumps via Empty Commits

**Minor version bump on release branch:**
```
Empty commit with #minor → release/v2 → build → minor bump → publish with "2x" tag
```

**Example:**
- We need to release a new minor version on `release/v2` after several patches
- Push an empty commit with the MINOR keyword:
  ```bash
  git checkout release/v2
  git commit --allow-empty -m "release: #minor version bump"
  git push origin release/v2
  ```
- The workflow builds and publishes version 2.1.0 with the `2x` tag

**Major version bump on main:**
```
Empty commit with #major → main → build → #major bump → publish with "latest" tag
```

**Example:**
- We want to release version 4.0.0 from `main` (currently at 3.x.x)
- Push an empty commit with the #major keyword:
  ```bash
  git checkout main
  git commit --allow-empty -m "release: #major version for breaking changes"
  git push origin main
  ```
- The workflow builds and publishes version 4.0.0 with the `beta` tag

### 4. Special Releases via Manual Workflow

**Beta release from feature branch:**
```
Manual trigger → feature/foo-bar→ select "minor" + tag "beta" → build → publish with "beta" tag
```

**Example:**
- We have new feature in development or just want to test out a beta before V1 for example:
  1. Go to Actions → Publish Engine Plugin → Run workflow
  2. Select our feature branch
  3. Set version bump to "minor"
  4. Set npm tag to "beta"
  5. Run the workflow
- The workflow builds and publishes with the `beta` tag
- Testers can install with `npm install @defra/forms-engine-plugin@beta`

