### PR TITLE
Fix issue when  option isn't passed

### DIFF
--- a/src/server/plugins/nunjucks/context.js
+++ b/src/server/plugins/nunjucks/context.js
@@ -42,7 +42,7 @@ export function context(request) {
     throw Error('Missing baseLayoutPath in plugin.options.nunjucks')
   }
 
-  if ('viewContext' in pluginStorage) {
+  if (typeof pluginStorage.viewContext === 'function') {
     consumerViewContext = pluginStorage.viewContext(request)
   }
 


### PR DESCRIPTION
<!--
  Thank you for contributing to DXT! Please follow the instructions in the comment tags.
  Unless you have been instructed, do not delete any text in this template.
-->

## Proposed change
When `viewContext` isn't provided, it defaults to undefined but exists as a key.
This change checks `viewContext` is callable.

I'll create a separate ticket to validate plugin options with joi, like all good [hapi plugins do](https://github.com/hapijs/inert/blob/master/lib/index.js#L41)

<!--
  Give a high-level description of the content of this pull request. No more than a couple of sentences.

  If you have consulted with the Defra Forms team prior to implementation, they will have provided you with an Azure DevOps work item number or (preferably) a link. Please include this.
-->

Azure DevOps work item:

## Type of change

<!--
  What type of change is this pull request? Mark the option with an X inside the brackets.
  If your change covers multiple categories, please split the pull request up to make it easier to review.
-->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc. (documentation, build updates, etc)

## Checklist

<!--
  Mark each completed item with an X, e.g. "[X] You have....".
  Feel free to chat to us on Slack if you have any questions.

  If you have not completed all of this, you are welcome to submit your pull request in a draft state
  to give us visibility and gather early feedback until it is ready for review.
-->

- [x] You have executed this code locally and it performs as expected.
- [x] You have added tests to verify your code works.
- [x] You have added code comments and JSDoc, where appropriate.
- [x] There is no commented-out code.
- [] You have added developer docs in `README.md` and `docs/*` (where appropriate, e.g. new features).
- [x] The tests are passing (`npm run test`).
- [x] The linting checks are passing (`npm run lint`).
- [x] The code has been formatted (`npm run format`).
