### PR TITLE
Fix documentation - remove legacy viewPaths

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -92,7 +92,7 @@ await server.register({
   }
 })
 
-const viewPaths = [join(config.get('appDir'), 'views')]
+const paths = [join(config.get('appDir'), 'views')]
 
 // Register the `forms-engine-plugin`
 await server.register({
@@ -104,7 +104,7 @@ await server.register({
      */
     nunjucks: {
       baseLayoutPath: 'your-base-layout.html', // the base page layout. Usually based off https://design-system.service.gov.uk/styles/page-template/
-      viewPaths // list of directories DXT should use to render your views. Must contain baseLayoutPath.
+      paths // list of directories DXT should use to render your views. Must contain baseLayoutPath.
     },
     /**
      * Services is what DXT uses to interact with external APIs

--- a/docs/PLUGIN_OPTIONS.md
+++ b/docs/PLUGIN_OPTIONS.md
@@ -10,7 +10,6 @@ The forms plugin is configured with [registration options](https://hapi.dev/api/
 - `filters` (optional) - A map of custom template filters to include
 - `cacheName` (optional) - The cache name to use. Defaults to hapi's [default server cache]. Recommended for production. See [here]
   (#custom-cache) for more details
-- `viewPaths` (optional) - Include additional view paths when using custom `page.view`s
 - `pluginPath` (optional) - The location of the plugin (defaults to `node_modules/@defra/forms-engine-plugin`)
 
 ## Services

--- a/src/server/plugins/engine/plugin.ts
+++ b/src/server/plugins/engine/plugin.ts
@@ -89,7 +89,6 @@ export interface PluginOptions {
   services?: Services
   controllers?: Record<string, typeof PageController>
   cacheName?: string
-  viewPaths?: string[]
   filters?: Record<string, FilterFunction>
   pluginPath?: string
   nunjucks: {


### PR DESCRIPTION
<!--
  Thank you for contributing to DXT! Please follow the instructions in the comment tags.
  Unless you have been instructed, do not delete any text in this template.
-->

## Proposed change

<!--
  Give a high-level description of the content of this pull request. No more than a couple of sentences.

  If you have consulted with the Defra Forms team prior to implementation, they will have provided you with an Azure DevOps work item number or (preferably) a link. Please include this.
-->

Remove legacy "viewPaths" option, which now does nothing since we introduced `nunjucks.paths`. This has no functional impact, it's essentially a documentation update.

Azure DevOps work item:

## Type of change

<!--
  What type of change is this pull request? Mark the option with an X inside the brackets.
  If your change covers multiple categories, please split the pull request up to make it easier to review.
-->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [X] Misc. (documentation, build updates, etc)

## Checklist

<!--
  Mark each completed item with an X, e.g. "[X] You have....".
  Feel free to chat to us on Slack if you have any questions.

  If you have not completed all of this, you are welcome to submit your pull request in a draft state
  to give us visibility and gather early feedback until it is ready for review.
-->

- [ ] You have executed this code locally and it performs as expected.
- [ ] You have added tests to verify your code works.
- [ ] You have added code comments and JSDoc, where appropriate.
- [ ] There is no commented-out code.
- [X] You have added developer docs in `README.md` and `docs/*` (where appropriate, e.g. new features).
- [ ] The tests are passing (`npm run test`).
- [ ] The linting checks are passing (`npm run lint`).
- [ ] The code has been formatted (`npm run format`).
