### PR TITLE
move config to be a consumer responsibility

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -84,7 +84,7 @@ export const config = convict({
   serviceName: {
     doc: 'Applications Service Name',
     format: String,
-    default: 'Submit a form to Defra'
+    default: 'Digital Express Toolkit'
   },
   serviceVersion: {
     doc: 'The service version, this variable is injected into your docker container in CDP environments',

--- a/src/server/devserver/dxt-devtool-baselayout.html
+++ b/src/server/devserver/dxt-devtool-baselayout.html
@@ -36,7 +36,7 @@
     homepageUrl: currentPath if context.isForceAccess else "https://defra.github.io/forms-engine-plugin/",
     containerClasses: "govuk-width-container",
     productName: productName | safe | trim,
-    serviceName: "Digital Express Toolkit",
+    serviceName: config.serviceName,
     serviceUrl: currentPath if context.isForceAccess else serviceUrl
   }) }}
 {% endblock %}

--- a/src/server/plugins/nunjucks/context.js
+++ b/src/server/plugins/nunjucks/context.js
@@ -4,7 +4,6 @@ import { basename, join } from 'node:path'
 import Boom from '@hapi/boom'
 import { StatusCodes } from 'http-status-codes'
 
-import pkg from '~/package.json' with { type: 'json' }
 import { config } from '~/src/config/index.js'
 import { createLogger } from '~/src/server/common/helpers/logging/logger.js'
 import {
@@ -32,6 +31,7 @@ export async function context(request) {
     !Boom.isBoom(response) && response?.statusCode === StatusCodes.OK
 
   const pluginStorage = request?.server.plugins['forms-engine-plugin']
+
   let consumerViewContext = {}
 
   if (!pluginStorage) {
@@ -51,15 +51,6 @@ export async function context(request) {
     // take consumers props first so we can override it
     ...consumerViewContext,
     baseLayoutPath: pluginStorage.baseLayoutPath,
-    appVersion: pkg.version,
-    config: {
-      cdpEnvironment: config.get('cdpEnvironment'),
-      designerUrl: config.get('designerUrl'),
-      feedbackLink: encodeUrl(config.get('feedbackLink')),
-      phaseTag: config.get('phaseTag'),
-      serviceName: config.get('serviceName'),
-      serviceVersion: config.get('serviceVersion')
-    },
     crumb: safeGenerateCrumb(request),
     currentPath: `${request.path}${request.url.search}`,
     previewMode: isPreviewMode ? formState : undefined,
@@ -87,6 +78,14 @@ export function devtoolContext(_request) {
   }
 
   return {
+    config: {
+      cdpEnvironment: config.get('cdpEnvironment'),
+      designerUrl: config.get('designerUrl'),
+      feedbackLink: encodeUrl(config.get('feedbackLink')),
+      phaseTag: config.get('phaseTag'),
+      serviceName: config.get('serviceName'),
+      serviceVersion: config.get('serviceVersion')
+    },
     assetPath: '/assets',
     getDxtAssetPath: (asset = '') => {
       return `/${webpackManifest?.[asset] ?? asset}`

--- a/src/server/plugins/nunjucks/types.js
+++ b/src/server/plugins/nunjucks/types.js
@@ -11,20 +11,13 @@
 
 /**
  * @typedef {object} ViewContext - Nunjucks view context
- * @property {string} appVersion - Application version
  * @property {string} [baseLayoutPath] - Base layout path
- * @property {Partial<Config>} config - Application config properties
  * @property {string} [crumb] - Cross-Site Request Forgery (CSRF) token
  * @property {string} [cspNonce] - Content Security Policy (CSP) nonce
  * @property {string} [currentPath] - Current path
  * @property {string} [previewMode] - Preview mode
  * @property {string} [slug] - Form slug
  * @property {FormContext} [context] - the current form context
- * @property {PluginOptions['viewContext']} [injectedViewContext] - the current form context
- */
-
-/**
- * @typedef {ReturnType<typeof config['getProperties']>} Config - Application config properties
  */
 
 /**


### PR DESCRIPTION
<!--
  Thank you for contributing to DXT! Please follow the instructions in the comment tags.
  Unless you have been instructed, do not delete any text in this template.
-->

## Proposed change

<!--
  Give a high-level description of the content of this pull request. No more than a couple of sentences.

  If you have consulted with the Defra Forms team prior to implementation, they will have provided you with an Azure DevOps work item number or (preferably) a link. Please include this.
-->

Removes the "config" from the view, instead relying on the consuming service to provide it if appropriate. Currently, we override whatever the consumer provides which breaks the forms-runner cookie banner functionality (as `config.googleAnalyticsTrackingId` won't exist).

Azure DevOps work item: 533186

## Type of change

<!--
  What type of change is this pull request? Mark the option with an X inside the brackets.
  If your change covers multiple categories, please split the pull request up to make it easier to review.
-->

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Misc. (documentation, build updates, etc)

## Checklist

<!--
  Mark each completed item with an X, e.g. "[X] You have....".
  Feel free to chat to us on Slack if you have any questions.

  If you have not completed all of this, you are welcome to submit your pull request in a draft state
  to give us visibility and gather early feedback until it is ready for review.
-->

- [X] You have executed this code locally and it performs as expected.
- [X] You have added tests to verify your code works.
- [X] You have added code comments and JSDoc, where appropriate.
- [X] There is no commented-out code.
- [ ] You have added developer docs in `README.md` and `docs/*` (where appropriate, e.g. new features).
- [X] The tests are passing (`npm run test`).
- [X] The linting checks are passing (`npm run lint`).
- [X] The code has been formatted (`npm run format`).
