### PR TITLE
DRAFT: WIP POC for session rehydration

### DIFF
--- a/src/server/plugins/engine/configureEnginePlugin.ts
+++ b/src/server/plugins/engine/configureEnginePlugin.ts
@@ -13,6 +13,21 @@ import * as defaultServices from '~/src/server/plugins/engine/services/index.js'
 import { formsService } from '~/src/server/plugins/engine/services/localFormsService.js'
 import { devtoolContext } from '~/src/server/plugins/nunjucks/context.js'
 import { type RouteConfig } from '~/src/server/types.js'
+import { FormSubmissionState } from './types.js'
+import { type Request } from '@hapi/hapi'
+import { FormRequest, FormRequestPayload } from '../../routes/types.js'
+
+const getIdentity = (request: Request | FormRequest | FormRequestPayload) => {
+  // const { userId, businessId, grantId } = request.auth.credentials || {}
+  // For testing purposes, we can hardcode the identity
+  const { userId, businessId, grantId } = {
+    userId: 'unicornBreederUserId',
+    businessId: 'unicornBreederBusinessId',
+    grantId: 'unicornBreederGrantId'
+  }
+  if (!userId || !businessId || !grantId) throw new Error('Missing identity')
+  return { userId, businessId, grantId }
+}
 
 export const configureEnginePlugin = async ({
   formFileName,
@@ -50,6 +65,19 @@ export const configureEnginePlugin = async ({
       },
       controllers,
       cacheName: 'session',
+      keyGenerator: (request: Request | FormRequest | FormRequestPayload) => {
+        // const { userId, businessId, grantId } = request.auth.credentials || {}
+        const { userId, businessId, grantId } = getIdentity(request)
+        if (!userId || !businessId || !grantId)
+          throw new Error('Missing identity')
+
+        return `${userId}:${businessId}:${grantId}`
+      },
+      rehydrationFn: async (
+        request: Request | FormRequest | FormRequestPayload
+      ) => {
+        return await fetchSavedStateFromApi(request)
+      },
       nunjucks: {
         baseLayoutPath: 'dxt-devtool-baselayout.html',
         paths: [join(findPackageRoot(), 'src/server/devserver')] // custom layout to make it really clear this is not the same as the runner
@@ -72,4 +100,40 @@ export async function getForm(importPath: string) {
 
   const { default: definition } = await formImport
   return definition
+}
+
+export async function fetchSavedStateFromApi(
+  request: Request | FormRequest | FormRequestPayload
+): Promise<FormSubmissionState> {
+  // const { userId, businessId, grantId } = request.auth.credentials || {}
+  const { userId, businessId, grantId } = getIdentity(request)
+  if (!userId || !businessId || !grantId) throw new Error('Missing identity')
+
+  let json: FormSubmissionState = {}
+  try {
+    const response = await fetch(
+      `http://localhost:3002/state/?userId=${userId}&businessId=${businessId}&grantId=${grantId}`,
+      {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      }
+    )
+
+    if (!response.ok) {
+      return {}
+    }
+
+    json = await response.json()
+  } catch (err) {
+    request.logger.error(
+      ['fetch-saved-state'],
+      'Failed to fetch saved state from API',
+      err
+    )
+    throw err
+  }
+
+  return json ?? {}
 }


### PR DESCRIPTION
## Proposed change

This PR is a PoC for session rehydration support in DXT to enable Save & Return functionality for users. Instead of relying solely on redis session state, this allows session data to be rehydrated from an external backing service (e.g., a backend API), ensuring that users can resume progress across browser sessions or devices.

Azure DevOps work item:

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc. (documentation, build updates, etc)

## Checklist

<!--
  Mark each completed item with an X, e.g. "[X] You have....".
  Feel free to chat to us on Slack if you have any questions.

  If you have not completed all of this, you are welcome to submit your pull request in a draft state
  to give us visibility and gather early feedback until it is ready for review.
-->

- [x] You have executed this code locally and it performs as expected.
- [ ] You have added tests to verify your code works.
- [ ] You have added code comments and JSDoc, where appropriate.
- [ ] There is no commented-out code.
- [ ] You have added developer docs in `README.md` and `docs/*` (where appropriate, e.g. new features).
- [ ] The tests are passing (`npm run test`).
- [ ] The linting checks are passing (`npm run lint`).
- [ ] The code has been formatted (`npm run format`).
