### PR TITLE
DF-168 Remove rebrand flag

### DIFF
--- a/src/client/stylesheets/_tag-env.scss
+++ b/src/client/stylesheets/_tag-env.scss
@@ -21,13 +21,4 @@
       margin: 0 0 0 govuk-spacing(2);
     }
   }
-
-  &-rebrand {
-    vertical-align: middle;
-
-    // Align with product name
-    @include govuk-media-query($from: tablet) {
-      margin: -3px 0 2px;
-    }
-  }
 }

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -79,16 +79,6 @@ export const config = convict({
   },
 
   /**
-   * Feature flags
-   */
-  showRebrand: {
-    doc: 'If this app should show the 2025 rebrand',
-    format: Boolean,
-    env: 'SHOW_GOVUK_REBRAND',
-    default: false
-  },
-
-  /**
    * Service
    */
   serviceName: {

--- a/src/server/plugins/engine/index.ts
+++ b/src/server/plugins/engine/index.ts
@@ -6,7 +6,8 @@ import { type FilterFunction } from '~/src/server/plugins/engine/types.js'
 import {
   checkComponentTemplates,
   checkErrorTemplates,
-  evaluate
+  evaluate,
+  govukRebrand
 } from '~/src/server/plugins/nunjucks/environment.js'
 import * as filters from '~/src/server/plugins/nunjucks/filters/index.js'
 
@@ -16,7 +17,8 @@ export { context } from '~/src/server/plugins/nunjucks/context.js'
 const globals = {
   checkComponentTemplates,
   checkErrorTemplates,
-  evaluate
+  evaluate,
+  govukRebrand
 }
 
 export const VIEW_PATH = 'src/server/plugins/engine/views'

--- a/src/server/plugins/engine/views/components/tag-env/template.njk
+++ b/src/server/plugins/engine/views/components/tag-env/template.njk
@@ -1,32 +1,9 @@
 {%- from "govuk/components/tag/macro.njk" import govukTag -%}
-{% if govukRebrand %}
-  {% set tagEnv = " app-tag--env app-tag--env-rebrand" %}
-{% else %}
-  {% set tagEnv = " app-tag--env" %}
-{% endif %}
-{%- switch params.env %}
-  {% case "local" %}
-    {% set text = "Local" %}
-    {% set classes = "govuk-tag--green" %}
-  {% case "dev" %}
-    {% set text = "Development" %}
-    {% set classes = "govuk-tag--grey" %}
-  {% case "test" %}
-    {% set text = "Test" %}
-    {% set classes = "govuk-tag--yellow" %}
-  {% case "ext-test" %}
-    {% set text = "External test" %}
-    {% set classes = "govuk-tag--yellow" %}
-  {% case "perf-test" %}
-    {% set text = "Performance test" %}
-    {% set classes = "govuk-tag--yellow" %}
-  {% case "prod" %}
-    {% set text = "Production" %}
-    {% set classes = "govuk-tag--red" %}
-  {% default %}
-    {% set text = params.env | replace("-", " ") | capitalize %}
-    {% set classes = "govuk-tag--grey" %}
-{% endswitch -%}
+
+{% set tagEnv = " app-tag--env" %}
+
+{% set text = params.env | replace("-", " ") | capitalize %}
+{% set classes = "govuk-tag--grey" %}
 
 {{ govukTag({
   text: text,

--- a/src/server/plugins/engine/views/components/tag-env/template.test.js
+++ b/src/server/plugins/engine/views/components/tag-env/template.test.js
@@ -1,66 +1,28 @@
 import { renderMacro } from '~/test/helpers/component-helpers.js'
 
 describe('Tag environment component', () => {
-  describe.each([
-    {
-      text: 'Local',
-      env: 'local',
-      colour: 'green'
-    },
-    {
-      text: 'Development',
-      env: 'dev',
-      colour: 'grey'
-    },
-    {
-      text: 'Test',
-      env: 'test',
-      colour: 'yellow'
-    },
-    {
-      text: 'External test',
-      env: 'ext-test',
-      colour: 'yellow'
-    },
-    {
-      text: 'Performance test',
-      env: 'perf-test',
-      colour: 'yellow'
-    },
-    {
-      text: 'Production',
-      env: 'prod',
-      colour: 'red'
-    },
-    {
-      text: 'Unknown environment',
-      env: 'unknown-environment',
-      colour: 'grey'
-    }
-  ])('Environment: $text', ({ text, env, colour }) => {
-    let $component = /** @type {HTMLElement | null} */ (null)
+  let $component = /** @type {HTMLElement | null} */ (null)
 
-    beforeEach(() => {
-      const { container } = renderMacro(
-        'appTagEnv',
-        'components/tag-env/macro.njk',
-        { params: { env } }
-      )
+  beforeEach(() => {
+    const { container } = renderMacro(
+      'appTagEnv',
+      'components/tag-env/macro.njk',
+      { params: { env: 'Devtool' } }
+    )
 
-      $component = container.getByRole('strong')
-    })
+    $component = container.getByRole('strong')
+  })
 
-    it('should render contents', () => {
-      expect($component).toBeInTheDocument()
-      expect($component).toHaveClass('govuk-tag')
-    })
+  it('should render contents', () => {
+    expect($component).toBeInTheDocument()
+    expect($component).toHaveClass('govuk-tag')
+  })
 
-    it('should have text content', () => {
-      expect($component).toHaveTextContent(text)
-    })
+  it('should have text content', () => {
+    expect($component).toHaveTextContent('Devtool')
+  })
 
-    it('should use environment colour', () => {
-      expect($component).toHaveClass(`govuk-tag--${colour}`)
-    })
+  it('should use environment colour', () => {
+    expect($component).toHaveClass(`govuk-tag--grey`)
   })
 })

--- a/src/server/plugins/nunjucks/environment.js
+++ b/src/server/plugins/nunjucks/environment.js
@@ -107,7 +107,11 @@ export function evaluate(template) {
   return context ? evaluateTemplate(template, context) : template
 }
 
-environment.addGlobal('evaluate', evaluate)
+export function govukRebrand() {
+  return true
+}
+
+environment.addGlobal('govukRebrand', govukRebrand())
 
 /**
  * @import { NunjucksContext } from '~/src/server/plugins/nunjucks/types.js'

--- a/src/server/plugins/nunjucks/environment.js
+++ b/src/server/plugins/nunjucks/environment.js
@@ -107,6 +107,8 @@ export function evaluate(template) {
   return context ? evaluateTemplate(template, context) : template
 }
 
+environment.addGlobal('evaluate', evaluate)
+
 export function govukRebrand() {
   return true
 }

--- a/src/server/plugins/nunjucks/environment.js
+++ b/src/server/plugins/nunjucks/environment.js
@@ -108,7 +108,6 @@ export function evaluate(template) {
 }
 
 environment.addGlobal('evaluate', evaluate)
-environment.addGlobal('govukRebrand', config.get('showRebrand'))
 
 /**
  * @import { NunjucksContext } from '~/src/server/plugins/nunjucks/types.js'


### PR DESCRIPTION
<!--
  Thank you for contributing to DXT! Please follow the instructions in the comment tags.
  Unless you have been instructed, do not delete any text in this template.
-->

## Proposed change

<!--
  Give a high-level description of the content of this pull request. No more than a couple of sentences.

  If you have consulted with the Defra Forms team prior to implementation, they will have provided you with an Azure DevOps work item number or (preferably) a link. Please include this.
-->

Enables govuk-frontend rebrand permanently, since we no longer need the feature flag. Also enables it on form pages.

Jira ticket: [DF-168](https://eaflood.atlassian.net/browse/DF-168)

## Type of change

<!--
  What type of change is this pull request? Mark the option with an X inside the brackets.
  If your change covers multiple categories, please split the pull request up to make it easier to review.
-->

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [X] Misc. (documentation, build updates, etc)

## Checklist

<!--
  Mark each completed item with an X, e.g. "[X] You have....".
  Feel free to chat to us on Slack if you have any questions.

  If you have not completed all of this, you are welcome to submit your pull request in a draft state
  to give us visibility and gather early feedback until it is ready for review.
-->

- [x] You have executed this code locally and it performs as expected.
- [ ] You have added tests to verify your code works.
- [x] You have added code comments and JSDoc, where appropriate.
- [x] There is no commented-out code.
- [x] You have added developer docs in `README.md` and `docs/*` (where appropriate, e.g. new features).
- [x] The tests are passing (`npm run test`).
- [x] The linting checks are passing (`npm run lint`).
- [x] The code has been formatted (`npm run format`).


[DF-168]: https://eaflood.atlassian.net/browse/DF-168?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ