### PR TITLE
Fix DF-80: Support for joined conditions

### DIFF
--- a/src/server/plugins/engine/models/FormModel.test.ts
+++ b/src/server/plugins/engine/models/FormModel.test.ts
@@ -390,4 +390,89 @@ describe('FormModel - Joined Conditions', () => {
     const falseState = { fsZNJr: 'Bob', DaBGpS: false }
     expect(joinedConditionPage?.condition?.fn(falseState)).toBe(false)
   })
+
+  describe('generateConditionAlias', () => {
+    it('should generate valid JavaScript identifiers from condition IDs', () => {
+      formDefinitionV2Schema.validate = jest
+        .fn()
+        .mockReturnValue({ value: joinedConditionsDefinition })
+
+      const model = new FormModel(joinedConditionsDefinition, {
+        basePath: 'test'
+      })
+
+      const evaluationState = { fsZNJr: 'Bob', DaBGpS: true }
+      const context = model.toConditionContext(
+        evaluationState,
+        model.conditions
+      )
+
+      expect(context).toHaveProperty(
+        'cond_d15aff7a_6224_40a2_8e5f_51a5af2f7910'
+      )
+      expect(context).toHaveProperty(
+        'cond_d1f9fcc7_f098_47e7_9d31_4f5ee57ba985'
+      )
+      expect(context).toHaveProperty(
+        'cond_db43c6bc_9ce6_478b_8345_4fff5eff2ba3'
+      )
+    })
+  })
+
+  describe('toConditionExpression', () => {
+    it('should handle V2 engine with display name replacement', () => {
+      formDefinitionV2Schema.validate = jest
+        .fn()
+        .mockReturnValue({ value: joinedConditionsDefinition })
+
+      const model = new FormModel(joinedConditionsDefinition, {
+        basePath: 'test'
+      })
+
+      const joinedCondition =
+        model.conditions['db43c6bc-9ce6-478b-8345-4fff5eff2ba3']
+      expect(joinedCondition).toBeDefined()
+
+      const stateTrue = { fsZNJr: 'Bob', DaBGpS: true }
+      const stateFalse = { fsZNJr: 'Alice', DaBGpS: false }
+
+      expect(joinedCondition?.fn(stateTrue)).toBe(true)
+      expect(joinedCondition?.fn(stateFalse)).toBe(false)
+
+      expect(joinedCondition?.expr).toBeDefined()
+      expect(typeof joinedCondition?.expr.evaluate).toBe('function')
+    })
+
+    it('should handle V1 engine without display name replacement', () => {
+      const model = new FormModel(definition, { basePath: 'test' })
+
+      const condition = model.conditions.ZCXeMz
+      expect(condition).toBeDefined()
+      expect(condition?.expr).toBeDefined()
+
+      const testState = { NIJphU: "ap'ostrophe's", iraEpG: "shouldn't've" }
+      expect(condition?.fn(testState)).toBe(true)
+    })
+
+    it('should handle conditions without display names', () => {
+      const definitionWithoutDisplayName = {
+        ...joinedConditionsDefinition,
+        conditions: joinedConditionsDefinition.conditions.map((condition) => ({
+          ...condition,
+          displayName: condition.displayName || 'fallback'
+        }))
+      }
+
+      formDefinitionV2Schema.validate = jest
+        .fn()
+        .mockReturnValue({ value: definitionWithoutDisplayName })
+
+      const model = new FormModel(definitionWithoutDisplayName, {
+        basePath: 'test'
+      })
+
+      expect(model.conditions).toBeDefined()
+      expect(Object.keys(model.conditions)).toHaveLength(3)
+    })
+  })
 })

--- a/test/form/definitions/joined-conditions-test.js
+++ b/test/form/definitions/joined-conditions-test.js
@@ -1,0 +1,122 @@
+import {
+  ComponentType,
+  ConditionType,
+  ControllerType,
+  Coordinator,
+  Engine,
+  OperatorName,
+  SchemaVersion
+} from '@defra/forms-model'
+
+/**
+ * @import { FormDefinition } from '@defra/forms-model'
+ */
+
+export default /** @satisfies {FormDefinition} */ ({
+  name: 'joined conditions test',
+  engine: Engine.V2,
+  schema: SchemaVersion.V2,
+  startPage: '/summary',
+  pages: [
+    {
+      title: 'What is your name?',
+      path: '/what-is-your-name',
+      components: [
+        {
+          type: ComponentType.TextField,
+          title: 'What is your name?',
+          name: 'fsZNJr',
+          id: '87b987e8-bcf9-4ff9-92af-57c34c45995a',
+          options: {},
+          schema: {}
+        }
+      ],
+      id: '3bdfacd3-c3f8-4a19-b280-7265023d854e',
+      next: []
+    },
+    {
+      title: 'Are you over 18?',
+      path: '/are-you-over-18',
+      components: [
+        {
+          type: ComponentType.YesNoField,
+          title: 'Are you over 18?',
+          name: 'DaBGpS',
+          id: 'c977e76e-49ab-4443-b93e-e19e8d9c81ac',
+          options: {}
+        }
+      ],
+      id: '7be18dec-0680-4c41-9981-357aa085429d',
+      next: [],
+      condition: 'd15aff7a-6224-40a2-8e5f-51a5af2f7910'
+    },
+    {
+      title: 'Joined condition page',
+      path: '/joined-condition-page',
+      components: [
+        {
+          type: ComponentType.TextField,
+          title: 'Joined condition page',
+          name: 'uxddlT',
+          id: '6be952dd-10f1-4642-8af6-18e4e082756e',
+          options: {},
+          schema: {}
+        }
+      ],
+      id: '97d57deb-0cf9-4321-bc1a-458e44279a5a',
+      next: [],
+      condition: 'db43c6bc-9ce6-478b-8345-4fff5eff2ba3'
+    },
+    {
+      id: '449a45f6-4541-4a46-91bd-8b8931b07b50',
+      title: 'Summary',
+      path: '/summary',
+      controller: ControllerType.Summary
+    }
+  ],
+  conditions: [
+    {
+      items: [
+        {
+          id: 'c833b177-0cba-49de-b670-a297c6db45b8',
+          componentId: 'c977e76e-49ab-4443-b93e-e19e8d9c81ac',
+          operator: OperatorName.Is,
+          value: true,
+          type: ConditionType.BooleanValue
+        }
+      ],
+      displayName: 'is over 18',
+      id: 'd1f9fcc7-f098-47e7-9d31-4f5ee57ba985'
+    },
+    {
+      items: [
+        {
+          id: 'fea9f725-3879-426a-8125-75d0da6995ac',
+          componentId: '87b987e8-bcf9-4ff9-92af-57c34c45995a',
+          operator: OperatorName.Is,
+          value: 'Bob',
+          type: ConditionType.StringValue
+        }
+      ],
+      displayName: 'is Bob',
+      id: 'd15aff7a-6224-40a2-8e5f-51a5af2f7910'
+    },
+    {
+      displayName: 'joined condition',
+      coordinator: Coordinator.AND,
+      items: [
+        {
+          id: 'a906e343-5d0e-421e-81a4-3afa68fac011',
+          conditionId: 'd15aff7a-6224-40a2-8e5f-51a5af2f7910'
+        },
+        {
+          id: '3b306a85-a365-4bfc-b9f0-3f868e896da2',
+          conditionId: 'd1f9fcc7-f098-47e7-9d31-4f5ee57ba985'
+        }
+      ],
+      id: 'db43c6bc-9ce6-478b-8345-4fff5eff2ba3'
+    }
+  ],
+  sections: [],
+  lists: []
+})


### PR DESCRIPTION
<!--
  Thank you for contributing to DXT! Please follow the instructions in the comment tags.
  Unless you have been instructed, do not delete any text in this template.
-->

## Proposed change

This PR enables the existing joined conditions in the Editor V2 to work by allowing expr-eval to successfully parse joined condition expressions.

Jira ticket:

## Type of change

<!--
  What type of change is this pull request? Mark the option with an X inside the brackets.
  If your change covers multiple categories, please split the pull request up to make it easier to review.
-->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc. (documentation, build updates, etc)

## Checklist

<!--
  Mark each completed item with an X, e.g. "[X] You have....".
  Feel free to chat to us on Slack if you have any questions.

  If you have not completed all of this, you are welcome to submit your pull request in a draft state
  to give us visibility and gather early feedback until it is ready for review.
-->

- [x] You have executed this code locally and it performs as expected.
- [x] You have added tests to verify your code works.
- [x] You have added code comments and JSDoc, where appropriate.
- [x] There is no commented-out code.
- [ ] You have added developer docs in `README.md` and `docs/*` (where appropriate, e.g. new features).
- [ ] The tests are passing (`npm run test`).
- [x] The linting checks are passing (`npm run lint`).
- [x] The code has been formatted (`npm run format`).
