### PR TITLE
Add globals to plugins registration options schema

### DIFF
--- a/src/server/plugins/engine/options.js
+++ b/src/server/plugins/engine/options.js
@@ -9,6 +9,7 @@ const pluginRegistrationOptionsSchema = Joi.object({
   services: Joi.object().optional(),
   controllers: Joi.object().pattern(Joi.string(), Joi.any()).optional(),
   cacheName: Joi.string().optional(),
+  globals: Joi.object().pattern(Joi.string(), Joi.any()).optional(),
   filters: Joi.object().pattern(Joi.string(), Joi.any()).optional(),
   pluginPath: Joi.string().optional(),
   nunjucks: Joi.object({


### PR DESCRIPTION
<!--
  Thank you for contributing to DXT! Please follow the instructions in the comment tags.
  Unless you have been instructed, do not delete any text in this template.
-->

## Proposed change

#128 did not include the new config option in the plugins registrations options schema. When updating to 1.3.0 and starting the server the following error was being logged.


```
[12:23:11.419] INFO (46200): Server failed to start :(
[12:23:11.419] ERROR (46200): Invalid plugin options
    err: {
      "type": "Error",
      "message": "Invalid plugin options",
      "stack":
          Error: Invalid plugin options
              at validatePluginOptions (/Users/alistairlaing/Work/defra/grants-ui/node_modules/@defra/forms-engine-plugin/src/server/plugins/engine/options.js:38:11)
              at Object.register (/Users/alistairlaing/Work/defra/grants-ui/node_modules/@defra/forms-engine-plugin/src/server/plugins/engine/plugin.ts:29:15)
              at internals.Server.register (/Users/alistairlaing/Work/defra/grants-ui/node_modules/@hapi/hapi/lib/server.js:494:35)
              at registerFormsPlugin (file:///Users/alistairlaing/Work/defra/grants-ui/src/server/index.js:106:16)
              at async createServer (file:///Users/alistairlaing/Work/defra/grants-ui/src/server/index.js:308:3)
              at async startServer (file:///Users/alistairlaing/Work/defra/grants-ui/src/server/common/helpers/start-server.js:10:14)
              at async file:///Users/alistairlaing/Work/defra/grants-ui/src/index.js:6:1
`
```

## Type of change

<!--
  What type of change is this pull request? Mark the option with an X inside the brackets.
  If your change covers multiple categories, please split the pull request up to make it easier to review.
-->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc. (documentation, build updates, etc)

## Checklist

<!--
  Mark each completed item with an X, e.g. "[X] You have....".
  Feel free to chat to us on Slack if you have any questions.

  If you have not completed all of this, you are welcome to submit your pull request in a draft state
  to give us visibility and gather early feedback until it is ready for review.
-->

- [ ] You have executed this code locally and it performs as expected.
- [ ] You have added tests to verify your code works.
- [x] You have added code comments and JSDoc, where appropriate.
- [x] There is no commented-out code.
- [x] You have added developer docs in `README.md` and `docs/*` (where appropriate, e.g. new features).
- [x] The tests are passing (`npm run test`).
- [x] The linting checks are passing (`npm run lint`).
- [x] The code has been formatted (`npm run format`).
