### PR TITLE
refactor: DF-380 - Add component dot getDisplayStringFromFormValue & …

### DIFF
--- a/src/server/plugins/engine/components/CheckboxesField.ts
+++ b/src/server/plugins/engine/components/CheckboxesField.ts
@@ -65,11 +65,8 @@ export class CheckboxesField extends SelectionControlField {
     return this.isValue(value) ? value : undefined
   }
 
-  getDisplayStringFromState(state: FormSubmissionState) {
+  getDisplayStringFromFormValue(selected: (string | number | boolean)[]) {
     const { items } = this
-
-    // Selected checkbox values
-    const selected = this.getFormValueFromState(state) ?? []
 
     // Map selected values to text
     return items
@@ -78,9 +75,9 @@ export class CheckboxesField extends SelectionControlField {
       .join(', ')
   }
 
-  getContextValueFromState(state: FormSubmissionState) {
-    const values = this.getFormValueFromState(state)
-
+  getContextValueFormFormValue(
+    values: (string | number | boolean)[] | undefined
+  ): (string | number | boolean)[] {
     /**
      * For evaluation context purposes, optional {@link CheckboxesField}
      * with an undefined value (i.e. nothing selected) should default to [].
@@ -93,6 +90,20 @@ export class CheckboxesField extends SelectionControlField {
      * should return true IF 'selectedchecks' is undefined, not throw and return false.
      */
     return values ?? []
+  }
+
+  getDisplayStringFromState(state: FormSubmissionState) {
+    // Selected checkbox values
+    const selected = this.getFormValueFromState(state) ?? []
+
+    // Map selected values to text
+    return this.getDisplayStringFromFormValue(selected)
+  }
+
+  getContextValueFromState(state: FormSubmissionState) {
+    const values = this.getFormValueFromState(state)
+
+    return this.getContextValueFormFormValue(values)
   }
 
   isValue(value?: FormStateValue | FormState): value is Item['value'][] {

--- a/src/server/plugins/engine/components/DatePartsField.ts
+++ b/src/server/plugins/engine/components/DatePartsField.ts
@@ -109,19 +109,24 @@ export class DatePartsField extends FormComponent {
     return this.isState(value) ? value : undefined
   }
 
-  getDisplayStringFromState(state: FormSubmissionState) {
-    const value = this.getFormValueFromState(state)
-
-    if (!value) {
+  getDisplayStringFromFormValue(formValue: DatePartsState | undefined) {
+    if (!formValue) {
       return ''
     }
 
-    return format(`${value.year}-${value.month}-${value.day}`, 'd MMMM yyyy')
+    return format(
+      `${formValue.year}-${formValue.month}-${formValue.day}`,
+      'd MMMM yyyy'
+    )
   }
 
-  getContextValueFromState(state: FormSubmissionState) {
+  getDisplayStringFromState(state: FormSubmissionState) {
     const value = this.getFormValueFromState(state)
 
+    return this.getDisplayStringFromFormValue(value)
+  }
+
+  getContextValueFormFormValue(value: DatePartsState | undefined) {
     if (
       !value ||
       !isValid(
@@ -137,6 +142,12 @@ export class DatePartsField extends FormComponent {
     }
 
     return format(`${value.year}-${value.month}-${value.day}`, 'yyyy-MM-dd')
+  }
+
+  getContextValueFromState(state: FormSubmissionState) {
+    const value = this.getFormValueFromState(state)
+
+    return this.getContextValueFormFormValue(value)
   }
 
   getViewModel(payload: FormPayload, errors?: FormSubmissionError[]) {

--- a/src/server/plugins/engine/components/FileUploadField.ts
+++ b/src/server/plugins/engine/components/FileUploadField.ts
@@ -149,8 +149,7 @@ export class FileUploadField extends FormComponent {
     return this.isValue(value) ? value : undefined
   }
 
-  getDisplayStringFromState(state: FormSubmissionState) {
-    const files = this.getFormValueFromState(state)
+  getDisplayStringFromFormValue(files: FileState[] | undefined): string {
     if (!files?.length) {
       return ''
     }
@@ -159,9 +158,21 @@ export class FileUploadField extends FormComponent {
     return `Uploaded ${files.length} ${unit}`
   }
 
+  getDisplayStringFromState(state: FormSubmissionState) {
+    const files = this.getFormValueFromState(state)
+
+    return this.getDisplayStringFromFormValue(files)
+  }
+
+  getContextValueFormFormValue(
+    files: UploadState | undefined
+  ): string[] | null {
+    return files?.map(({ status }) => status.form.file.fileId) ?? null
+  }
+
   getContextValueFromState(state: FormSubmissionState) {
     const files = this.getFormValueFromState(state)
-    return files?.map(({ status }) => status.form.file.fileId) ?? null
+    return this.getContextValueFormFormValue(files)
   }
 
   getViewModel(

--- a/src/server/plugins/engine/components/FormComponent.ts
+++ b/src/server/plugins/engine/components/FormComponent.ts
@@ -157,17 +157,21 @@ export class FormComponent extends ComponentBase {
     }
   }
 
-  getDisplayStringFromState(state: FormSubmissionState): string {
-    const value = this.getFormValueFromState(state)
+  getDisplayStringFromFormValue(value: FormValue | FormPayload): string {
+    // Map selected values to text
     // eslint-disable-next-line @typescript-eslint/no-base-to-string
     return this.isValue(value) ? value.toString() : ''
   }
 
-  getContextValueFromState(
-    state: FormSubmissionState
-  ): Item['value'] | Item['value'][] | null {
+  getDisplayStringFromState(state: FormSubmissionState): string {
     const value = this.getFormValueFromState(state)
+    // eslint-disable-next-line @typescript-eslint/no-base-to-string
+    return this.getDisplayStringFromFormValue(value)
+  }
 
+  getContextValueFormFormValue(
+    value: FormValue | FormPayload
+  ): Item['value'] | Item['value'][] | null {
     // Filter object field values
     if (this.isState(value)) {
       const values = Object.values(value).filter(isFormValue)
@@ -180,6 +184,14 @@ export class FormComponent extends ComponentBase {
     }
 
     return this.isValue(value) ? value : null
+  }
+
+  getContextValueFromState(
+    state: FormSubmissionState
+  ): Item['value'] | Item['value'][] | null {
+    const value = this.getFormValueFromState(state)
+
+    return this.getContextValueFormFormValue(value)
   }
 
   isValue(

--- a/src/server/plugins/engine/components/ListFormComponent.ts
+++ b/src/server/plugins/engine/components/ListFormComponent.ts
@@ -99,17 +99,24 @@ export class ListFormComponent extends FormComponent {
     return selected.at(0)?.value
   }
 
-  getDisplayStringFromState(state: FormSubmissionState) {
+  getDisplayStringFromFormValue(
+    value: string | number | boolean | Item['value'][] | undefined
+  ): string {
     const { items } = this
 
-    // Allow for array values via subclass
-    const value = this.getFormValueFromState(state)
     const values = [value ?? []].flat()
 
     return items
       .filter((item) => values.includes(item.value))
       .map((item) => item.text)
       .join(', ')
+  }
+
+  getDisplayStringFromState(state: FormSubmissionState) {
+    // Allow for array values via subclass
+    const value = this.getFormValueFromState(state)
+
+    return this.getDisplayStringFromFormValue(value)
   }
 
   getViewModel(payload: FormPayload, errors?: FormSubmissionError[]) {

--- a/src/server/plugins/engine/components/MonthYearField.ts
+++ b/src/server/plugins/engine/components/MonthYearField.ts
@@ -103,9 +103,7 @@ export class MonthYearField extends FormComponent {
     return MonthYearField.isMonthYear(value) ? value : undefined
   }
 
-  getDisplayStringFromState(state: FormSubmissionState) {
-    const value = this.getFormValueFromState(state)
-
+  getDisplayStringFromFormValue(value: MonthYearState | undefined): string {
     if (!value) {
       return ''
     }
@@ -117,9 +115,15 @@ export class MonthYearField extends FormComponent {
     return `${monthString} ${value.year}`
   }
 
-  getContextValueFromState(state: FormSubmissionState) {
+  getDisplayStringFromState(state: FormSubmissionState) {
     const value = this.getFormValueFromState(state)
 
+    return this.getDisplayStringFromFormValue(value)
+  }
+
+  getContextValueFormFormValue(
+    value: MonthYearState | undefined
+  ): string | null {
     if (
       !value ||
       !isValid(
@@ -135,6 +139,12 @@ export class MonthYearField extends FormComponent {
     }
 
     return format(`${value.year}-${value.month}-01`, 'yyyy-MM')
+  }
+
+  getContextValueFromState(state: FormSubmissionState) {
+    const value = this.getFormValueFromState(state)
+
+    return this.getContextValueFormFormValue(value)
   }
 
   getViewModel(payload: FormPayload, errors?: FormSubmissionError[]) {

--- a/src/server/plugins/engine/components/UkAddressField.ts
+++ b/src/server/plugins/engine/components/UkAddressField.ts
@@ -110,18 +110,28 @@ export class UkAddressField extends FormComponent {
     return this.isState(value) ? value : undefined
   }
 
-  getDisplayStringFromState(state: FormSubmissionState) {
-    return this.getContextValueFromState(state)?.join(', ') ?? ''
-  }
-
-  getContextValueFromState(state: FormSubmissionState) {
-    const value = this.getFormValueFromState(state)
-
+  getContextValueFormFormValue(value: UkAddressState | undefined) {
     if (!value) {
       return null
     }
 
     return Object.values(value).filter(Boolean)
+  }
+
+  getContextValueFromState(state: FormSubmissionState) {
+    const value = this.getFormValueFromState(state)
+
+    return this.getContextValueFormFormValue(value)
+  }
+
+  getDisplayStringFromFormValue(value: UkAddressState | undefined): string {
+    return this.getContextValueFormFormValue(value)?.join(', ') ?? ''
+  }
+
+  getDisplayStringFromState(state: FormSubmissionState) {
+    const value = this.getFormValueFromState(state)
+
+    return this.getDisplayStringFromFormValue(value)
   }
 
   /**


### PR DESCRIPTION
…getContextValueFormFormValue

<!--
  Thank you for contributing to DXT! Please follow the instructions in the comment tags.
  Unless you have been instructed, do not delete any text in this template.
-->

## Proposed change
This is a refactor to add `getContextValueFormFormValue` and `getDisplayStringFromFormValue` methods to `FormComponent`s, which will allow us to use the same logic for handling notify email formatting in separate service as in the plugin.

<!--
  Give a high-level description of the content of this pull request. No more than a couple of sentences.

  If you have consulted with the Defra Forms team prior to implementation, they will have provided you with an Azure DevOps work item number or (preferably) a link. Please include this.
-->

Jira ticket:

## Type of change

<!--
  What type of change is this pull request? Mark the option with an X inside the brackets.
  If your change covers multiple categories, please split the pull request up to make it easier to review.
-->

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Misc. (documentation, build updates, etc)

## Checklist

<!--
  Mark each completed item with an X, e.g. "[X] You have....".
  Feel free to chat to us on Slack if you have any questions.

  If you have not completed all of this, you are welcome to submit your pull request in a draft state
  to give us visibility and gather early feedback until it is ready for review.
-->

- [X] You have executed this code locally and it performs as expected.
- [X] You have added tests to verify your code works.
- [ ] You have added code comments and JSDoc, where appropriate.
- [ ] There is no commented-out code.
- [ ] You have added developer docs in `README.md` and `docs/*` (where appropriate, e.g. new features).
- [X] The tests are passing (`npm run test`).
- [X] The linting checks are passing (`npm run lint`).
- [X] The code has been formatted (`npm run format`).
