### PR TITLE
Make save and return button disabled by default

### DIFF
--- a/src/server/plugins/engine/models/SummaryViewModel.test.ts
+++ b/src/server/plugins/engine/models/SummaryViewModel.test.ts
@@ -279,11 +279,11 @@ describe('SummaryPageController', () => {
   })
 
   describe('Save and Return functionality', () => {
-    it('should show save and return button on summary page', () => {
-      expect(controller.shouldShowSaveAndReturn(request.server)).toBe(true)
+    it('should not show save and return button on summary page by default', () => {
+      expect(controller.shouldShowSaveAndReturn(request.server)).toBe(false)
     })
 
-    it('should handle save and return from summary page', () => {
+    it('should not handle save and return from summary page by default', () => {
       const state: FormState = {
         $$__referenceNumber: 'foobar',
         orderType: 'collection',
@@ -293,7 +293,7 @@ describe('SummaryPageController', () => {
       const context = model.getFormContext(request, state)
       const viewModel = controller.getViewModel(request, context)
 
-      expect(viewModel).toHaveProperty('allowSaveAndReturn', true)
+      expect(viewModel).toHaveProperty('allowSaveAndReturn', false)
     })
 
     it('should display correct page title', () => {

--- a/src/server/plugins/engine/pageControllers/FileUploadPageController.test.ts
+++ b/src/server/plugins/engine/pageControllers/FileUploadPageController.test.ts
@@ -1119,10 +1119,10 @@ describe('FileUploadPageController', () => {
     })
   })
 
-  describe('shouldShowSaveAndReturn', () => {
-    it('should return true when save and return is enabled', () => {
+  describe('shouldNotShowSaveAndReturnByDefault', () => {
+    it('should return false when save and return is disabled by default', () => {
       expect(controller.shouldShowSaveAndReturn(serverWithSaveAndReturn)).toBe(
-        true
+        false
       )
     })
   })

--- a/src/server/plugins/engine/pageControllers/QuestionPageController.test.ts
+++ b/src/server/plugins/engine/pageControllers/QuestionPageController.test.ts
@@ -1327,7 +1327,7 @@ describe('Save and Return functionality', () => {
   describe('shouldShowSaveAndReturn', () => {
     it('should return true by default', () => {
       expect(controller1.shouldShowSaveAndReturn(serverWithSaveAndReturn)).toBe(
-        true
+        false
       )
     })
   })

--- a/src/server/plugins/engine/pageControllers/QuestionPageController.ts
+++ b/src/server/plugins/engine/pageControllers/QuestionPageController.ts
@@ -51,7 +51,6 @@ import { merge } from '~/src/server/services/cacheService.js'
 export class QuestionPageController extends PageController {
   collection: ComponentCollection
   errorSummaryTitle = 'There is a problem'
-  allowSaveAndReturn = true
 
   constructor(model: FormModel, pageDef: Page) {
     super(model, pageDef)

--- a/src/server/plugins/engine/pageControllers/RepeatPageController.test.ts
+++ b/src/server/plugins/engine/pageControllers/RepeatPageController.test.ts
@@ -271,10 +271,10 @@ describe('RepeatPageController', () => {
     })
   })
 
-  describe('shouldShowSaveAndReturn', () => {
-    it('should return true when save and return is enabled', () => {
+  describe('shouldNotShowSaveAndReturnByDefault', () => {
+    it('should return false when save and return is disabled by default', () => {
       expect(controller.shouldShowSaveAndReturn(serverWithSaveAndReturn)).toBe(
-        true
+        false
       )
     })
   })

--- a/test/form/save-and-return.test.js
+++ b/test/form/save-and-return.test.js
@@ -57,20 +57,17 @@ describe('Save and Return functionality', () => {
   })
 
   describe('Save and Return button', () => {
-    it('should render the save and return button on question pages with the correct name and value attributes', async () => {
+    it('should not render the save and return button on question pages with the correct name and value attributes', async () => {
       const { container } = await renderResponse(server, {
         url: `${basePath}/licence`,
         headers
       })
 
-      const $saveButton = container.getByRole('button', {
+      const $saveButton = container.queryByRole('button', {
         name: 'Save and return'
       })
 
-      expect($saveButton).toBeInTheDocument()
-      expect($saveButton).toHaveClass('govuk-button--secondary')
-      expect($saveButton).toHaveAttribute('name', 'action')
-      expect($saveButton).toHaveAttribute('value', 'save-and-return')
+      expect($saveButton).not.toBeInTheDocument()
     })
   })
 


### PR DESCRIPTION
## Proposed change

Make save and return button disabled by default

Jira ticket: TGC-821

## Type of change

Make save and return button disabled by default

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc. (documentation, build updates, etc)

## Checklist

<!--
  Mark each completed item with an X, e.g. "[X] You have....".
  Feel free to chat to us on Slack if you have any questions.

  If you have not completed all of this, you are welcome to submit your pull request in a draft state
  to give us visibility and gather early feedback until it is ready for review.
-->

- [x] You have executed this code locally and it performs as expected.
- [x] You have added tests to verify your code works.
- [x] You have added code comments and JSDoc, where appropriate.
- [x] There is no commented-out code.
- [ ] You have added developer docs in `README.md` and `docs/*` (where appropriate, e.g. new features).
- [x] The tests are passing (`npm run test`).
- [x] The linting checks are passing (`npm run lint`).
- [x] The code has been formatted (`npm run format`).
