### PR TITLE
TGC-842: Fix multilineTextField render issue

### DIFF
--- a/src/server/plugins/engine/components/MultilineTextField.test.ts
+++ b/src/server/plugins/engine/components/MultilineTextField.test.ts
@@ -161,6 +161,17 @@ describe('MultilineTextField', () => {
         expect(answer2).toBe('')
       })
 
+      it('returns multiline text from state, collapsing multiple newlines into one', () => {
+        const state1 = getFormState('Line 1\r\nLine 2\r\nLine 3')
+        const state2 = getFormState('Line 1\r\n\r\nLine 2\r\n\r\n\r\nLine 3')
+
+        const answer1 = getAnswer(field, state1)
+        const answer2 = getAnswer(field, state2)
+
+        expect(answer1).toBe('Line 1<br>Line 2<br>Line 3<br>')
+        expect(answer2).toBe('Line 1<br>Line 2<br>Line 3<br>')
+      })
+
       it('returns payload from state', () => {
         const state1 = getFormState('Textarea')
         const state2 = getFormState(null)

--- a/src/server/plugins/engine/components/helpers/components.ts
+++ b/src/server/plugins/engine/components/helpers/components.ts
@@ -315,7 +315,7 @@ export function getAnswerMarkdown(
   } else if (field instanceof Components.MultilineTextField) {
     // Preserve Multiline text new lines
     answerEscaped = answer
-      .split(/\r?\n/)
+      .split(/(?:\r?\n)+/)
       .map(escapeMarkdown)
       .join('\n')
       .concat('\n')


### PR DESCRIPTION
<!--
  Thank you for contributing to DXT! Please follow the instructions in the comment tags.
  Unless you have been instructed, do not delete any text in this template.
-->

## Bug fix

When a multilineTextField component has multiple newlines, the rendering of that output in the summary list is wrong, e.g.

```
line 1

line 2

line 3
```

Is displayed as

```
line 1line2line 3
```

Ideally the rendered output in the summary list would exactly match the user's input, but `marked` does not seem to be able to output multiple newlines. Given this limitation and the space constraints of the summary list, I think it's ok to just collapse the newlines into one and render as if the input had been:

```
line 1
line 2
line 3
```

Which works fine.

<!--
  Give a high-level description of the content of this pull request. No more than a couple of sentences.

  If you have consulted with the Defra Forms team prior to implementation, they will have provided you with an Azure DevOps work item number or (preferably) a link. Please include this.
-->

Jira ticket: https://eaflood.atlassian.net/browse/TGC-842

(Description basically the same as above)

## Type of change

<!--
  What type of change is this pull request? Mark the option with an X inside the brackets.
  If your change covers multiple categories, please split the pull request up to make it easier to review.
-->

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc. (documentation, build updates, etc)

## Checklist

<!--
  Mark each completed item with an X, e.g. "[X] You have....".
  Feel free to chat to us on Slack if you have any questions.

  If you have not completed all of this, you are welcome to submit your pull request in a draft state
  to give us visibility and gather early feedback until it is ready for review.
-->

- [X] You have executed this code locally and it performs as expected.
- [ ] You have added tests to verify your code works.
- [ ] You have added code comments and JSDoc, where appropriate.
- [X] There is no commented-out code.
- [ ] You have added developer docs in `README.md` and `docs/*` (where appropriate, e.g. new features).
- [X] The tests are passing (`npm run test`).
- [X] The linting checks are passing (`npm run lint`).
- [X] The code has been formatted (`npm run format`).
