### PR TITLE
DF-370: Allow save and exit from the repeater summary page

### DIFF
--- a/src/server/plugins/engine/pageControllers/RepeatPageController.ts
+++ b/src/server/plugins/engine/pageControllers/RepeatPageController.ts
@@ -34,6 +34,7 @@ export class RepeatPageController extends QuestionPageController {
   listSummaryViewName = 'repeat-list-summary'
   listDeleteViewName = 'item-delete'
   repeat: Repeat
+  allowSaveAndExit = true
 
   constructor(model: FormModel, pageDef: PageRepeat) {
     super(model, pageDef)
@@ -257,6 +258,11 @@ export class RepeatPageController extends QuestionPageController {
         return super.proceed(request, h, nextPath)
       }
 
+      // Check if this is a save-and-exit action
+      if (action === FormAction.SaveAndExit) {
+        return this.handleSaveAndExit(request, context, h)
+      }
+
       const nextPath = this.getNextPath(context)
       return super.proceed(request, h, nextPath)
     }
@@ -433,7 +439,8 @@ export class RepeatPageController extends QuestionPageController {
       showTitle: true,
       context,
       errors,
-      checkAnswers: [{ summaryList }]
+      checkAnswers: [{ summaryList }],
+      allowSaveAndExit: this.shouldShowSaveAndExit(request.server)
     }
   }
 

--- a/src/server/plugins/engine/types.ts
+++ b/src/server/plugins/engine/types.ts
@@ -329,6 +329,7 @@ export interface RepeaterSummaryPageViewModel extends PageViewModelBase {
   errors?: FormSubmissionError[]
   checkAnswers: CheckAnswers[]
   repeatTitle: string
+  allowSaveAndExit: boolean
 }
 
 export interface FeaturedFormPageViewModel extends FormPageViewModel {

--- a/src/server/plugins/engine/views/repeat-list-summary.html
+++ b/src/server/plugins/engine/views/repeat-list-summary.html
@@ -24,10 +24,10 @@
         {{ govukSummaryList(section.summaryList) }}
       {% endfor %}
 
-      <div class="govuk-button-group">
-        <form method="post" novalidate>
-          <input type="hidden" name="crumb" value="{{ crumb }}">
+      <form method="post" novalidate>
+        <input type="hidden" name="crumb" value="{{ crumb }}">
 
+        <div class="govuk-button-group">
           {{ govukButton({
             text: "Continue",
             name: "action",
@@ -42,8 +42,18 @@
             classes: "govuk-button--secondary",
             preventDoubleClick: true
           }) }}
-        </form>
-      </div>
+
+          {% if allowSaveAndExit %}
+            {{ govukButton({
+              text: "Save and exit",
+              classes: "govuk-button--secondary",
+              name: "action",
+              value: "save-and-exit",
+              preventDoubleClick: true
+            }) }}
+          {% endif %}
+        </div>
+      </form>
     </div>
   </div>
 

--- a/test/form/repeat.test.js
+++ b/test/form/repeat.test.js
@@ -362,7 +362,8 @@ describe('Repeat POST tests', () => {
   beforeAll(async () => {
     server = await createServer({
       formFileName: 'repeat.js',
-      formFilePath: resolve(import.meta.dirname, '../form/definitions')
+      formFilePath: resolve(import.meta.dirname, '../form/definitions'),
+      saveAndExit: (request, h, _context) => h.redirect('/my-save-and-exit')
     })
 
     const model = server.app.model
@@ -629,6 +630,24 @@ describe('Repeat POST tests', () => {
       retrievalKey: 'enrique.chase@defra.gov.uk',
       sessionId: expect.any(String)
     })
+  })
+
+  test('POST /pizza-order/summary with 2 items SAVE_AND_EXIT returns 303 to /summary', async () => {
+    const { headers } = await createRepeatItem(server, repeatPage)
+
+    await createRepeatItem(server, repeatPage, 2, headers)
+
+    const res1 = await server.inject({
+      url: `${basePath}/pizza-order/summary`,
+      method: 'POST',
+      headers,
+      payload: {
+        action: FormAction.SaveAndExit
+      }
+    })
+
+    expect(res1.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY)
+    expect(res1.headers.location).toBe('/my-save-and-exit')
   })
 })
 


### PR DESCRIPTION
<!--
  Thank you for contributing to DXT! Please follow the instructions in the comment tags.
  Unless you have been instructed, do not delete any text in this template.
-->

## Proposed change

https://eaflood.atlassian.net/browse/DF-370

Allow save and exit from the repeater summary page

<!--
  Give a high-level description of the content of this pull request. No more than a couple of sentences.

  If you have consulted with the Defra Forms team prior to implementation, they will have provided you with an Azure DevOps work item number or (preferably) a link. Please include this.
-->

Jira ticket:

## Type of change

<!--
  What type of change is this pull request? Mark the option with an X inside the brackets.
  If your change covers multiple categories, please split the pull request up to make it easier to review.
-->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc. (documentation, build updates, etc)

## Checklist

<!--
  Mark each completed item with an X, e.g. "[X] You have....".
  Feel free to chat to us on Slack if you have any questions.

  If you have not completed all of this, you are welcome to submit your pull request in a draft state
  to give us visibility and gather early feedback until it is ready for review.
-->

- [x] You have executed this code locally and it performs as expected.
- [x] You have added tests to verify your code works.
- [x] You have added code comments and JSDoc, where appropriate.
- [x] There is no commented-out code.
- [x] You have added developer docs in `README.md` and `docs/*` (where appropriate, e.g. new features).
- [x] The tests are passing (`npm run test`).
- [x] The linting checks are passing (`npm run lint`).
- [x] The code has been formatted (`npm run format`).
