### PR TITLE
[SPIKE] New manifest to help build predictable URLs

### DIFF
--- a/src/server/constants.js
+++ b/src/server/constants.js
@@ -1,2 +1,2 @@
 export const PREVIEW_PATH_PREFIX = '/preview'
-export const FORM_PREFIX = ''
+export const FORM_PREFIX = '/my-custom-prefix/with/nested/path'

--- a/src/server/plugins/forms/index.ts
+++ b/src/server/plugins/forms/index.ts
@@ -1,0 +1,27 @@
+import { type Plugin, type Server } from '@hapi/hapi'
+
+import enginePlugin from '~/src/server/plugins/engine/index.js'
+import { type PluginOptions } from '~/src/server/plugins/forms/types.js'
+import { plugin as manifestPlugin } from '~/src/server/plugins/manifest/index.js'
+
+export const plugin = {
+  name: '@defra/forms-index',
+  dependencies: ['@hapi/crumb', '@hapi/yar', 'hapi-pino'],
+  multiple: true,
+  async register(server: Server, options?: PluginOptions) {
+    // routes that should have a predictable URL
+    await server.register({
+      plugin: manifestPlugin,
+      options
+    })
+
+    // forms can be prefixed to prevent collisions
+    await server.register(
+      {
+        plugin: enginePlugin,
+        options: options?.engine
+      },
+      options?.serverRegistrationOptions
+    )
+  }
+} satisfies Plugin<PluginOptions>

--- a/src/server/plugins/forms/types.ts
+++ b/src/server/plugins/forms/types.ts
@@ -1,0 +1,8 @@
+import { type ServerRegisterOptions } from '@hapi/hapi'
+
+import { type PluginOptions as EnginePluginOptions } from '~/src/server/plugins/engine/types.js'
+
+export interface PluginOptions {
+  engine: EnginePluginOptions
+  serverRegistrationOptions?: ServerRegisterOptions
+}

--- a/src/server/plugins/manifest/index.ts
+++ b/src/server/plugins/manifest/index.ts
@@ -1,0 +1,21 @@
+import { type Plugin, type Server } from '@hapi/hapi'
+
+import { type PluginOptions } from '~/src/server/plugins/forms/types.js'
+
+export const plugin = {
+  name: '@defra/forms-manifest',
+  multiple: false,
+  register(server: Server, options: PluginOptions) {
+    server.route({
+      method: 'GET',
+      path: '/forms-manifest',
+      handler: (_, h) => {
+        const prefix = options.serverRegistrationOptions?.routes?.prefix ?? ''
+
+        return h.response({
+          engineBaseUrl: prefix
+        })
+      }
+    })
+  }
+} satisfies Plugin<PluginOptions>

--- a/test/client/javascripts/file-upload.test.js
+++ b/test/client/javascripts/file-upload.test.js
@@ -1,7 +1,4 @@
-import {
-  buildUploadStatusUrl,
-  initFileUpload
-} from '~/src/client/javascripts/file-upload.js'
+import { initFileUpload } from '~/src/client/javascripts/file-upload.js'
 
 describe('File Upload Client JS', () => {
   beforeEach(() => {
@@ -1345,61 +1342,61 @@ describe('File Upload Client JS', () => {
   })
 })
 
-describe('buildUploadStatusUrl', () => {
-  it('works with no prefix', () => {
-    expect(buildUploadStatusUrl('/my-form/file-upload-page', '123')).toBe(
-      '/upload-status/123'
-    )
+// describe('buildUploadStatusUrl', () => {
+//   it('works with no prefix', () => {
+//     expect(buildUploadStatusUrl('/my-form/file-upload-page', '123')).toBe(
+//       '/upload-status/123'
+//     )
 
-    expect(
-      buildUploadStatusUrl('/preview/draft/my-form/file-upload-page', '123')
-    ).toBe('/upload-status/123')
+//     expect(
+//       buildUploadStatusUrl('/preview/draft/my-form/file-upload-page', '123')
+//     ).toBe('/upload-status/123')
 
-    expect(
-      buildUploadStatusUrl('/preview/live/my-form/file-upload-page', '123')
-    ).toBe('/upload-status/123')
-  })
+//     expect(
+//       buildUploadStatusUrl('/preview/live/my-form/file-upload-page', '123')
+//     ).toBe('/upload-status/123')
+//   })
 
-  it('works with a prefix with a single level', () => {
-    expect(buildUploadStatusUrl('/form/my-form/file-upload-page', '123')).toBe(
-      '/form/upload-status/123'
-    )
+//   it('works with a prefix with a single level', () => {
+//     expect(buildUploadStatusUrl('/form/my-form/file-upload-page', '123')).toBe(
+//       '/form/upload-status/123'
+//     )
 
-    expect(
-      buildUploadStatusUrl(
-        '/form/preview/draft/my-form/file-upload-page',
-        '123'
-      )
-    ).toBe('/form/upload-status/123')
+//     expect(
+//       buildUploadStatusUrl(
+//         '/form/preview/draft/my-form/file-upload-page',
+//         '123'
+//       )
+//     ).toBe('/form/upload-status/123')
 
-    expect(
-      buildUploadStatusUrl('/form/preview/live/my-form/file-upload-page', '123')
-    ).toBe('/form/upload-status/123')
-  })
+//     expect(
+//       buildUploadStatusUrl('/form/preview/live/my-form/file-upload-page', '123')
+//     ).toBe('/form/upload-status/123')
+//   })
 
-  it('works with a prefix with multiple levels', () => {
-    expect(
-      buildUploadStatusUrl('/org/form/my-form/file-upload-page', '123')
-    ).toBe('/org/form/upload-status/123')
+//   it('works with a prefix with multiple levels', () => {
+//     expect(
+//       buildUploadStatusUrl('/org/form/my-form/file-upload-page', '123')
+//     ).toBe('/org/form/upload-status/123')
 
-    expect(
-      buildUploadStatusUrl(
-        '/org/form/preview/draft/my-form/file-upload-page',
-        '123'
-      )
-    ).toBe('/org/form/upload-status/123')
+//     expect(
+//       buildUploadStatusUrl(
+//         '/org/form/preview/draft/my-form/file-upload-page',
+//         '123'
+//       )
+//     ).toBe('/org/form/upload-status/123')
 
-    expect(
-      buildUploadStatusUrl(
-        '/org/form/preview/live/my-form/file-upload-page',
-        '123'
-      )
-    ).toBe('/org/form/upload-status/123')
-  })
+//     expect(
+//       buildUploadStatusUrl(
+//         '/org/form/preview/live/my-form/file-upload-page',
+//         '123'
+//       )
+//     ).toBe('/org/form/upload-status/123')
+//   })
 
-  it('trims trailing slashes', () => {
-    expect(buildUploadStatusUrl('/my-form/file-upload-page/', '123')).toBe(
-      '/upload-status/123'
-    )
-  })
-})
+//   it('trims trailing slashes', () => {
+//     expect(buildUploadStatusUrl('/my-form/file-upload-page/', '123')).toBe(
+//       '/upload-status/123'
+//     )
+//   })
+// })


### PR DESCRIPTION
### Context
when a user uploads a file, we poll the backend to check the file upload status at /{prefix}/upload-status/{uploadId}. However, prefix is not known to the client-side JS and may even be missing if a developer doesn't register forms-engine-plugin with a prefix.

### Problem
currently, our file-upload JS breaks if the plugin doesn't have a prefix. So we need better logic to determine the "base path" of the plugin.

### Solution
Introduces a new manifest plugin that sits on a fixed URL, giving client-side JS a predictable path to build URLs by using the config it returns.

`buildUploadStatusUrl` shows why this is useful.

**Pros:**
- Allows us to build predictable URLs
- Means URLs aren't brittle, e.g. if the URL structure of file upload pages changed

**Cons:**
- Server registration options for `engine` are passed through as plugin registration options. Slightly unusual, although not major.
- Collissions if our plugin is registered multiple times. Moderately important, although I don't think anyone does this currently. 

<img width="2804" height="3068" alt="image" src="https://github.com/user-attachments/assets/78285a73-9d6f-4643-a355-21e55bfcbc25" />
