### PR TITLE
Fixes Surfaced Through CSP Changes

### DIFF
--- a/src/server/plugins/engine/components/PaymentField.ts
+++ b/src/server/plugins/engine/components/PaymentField.ts
@@ -244,7 +244,9 @@ export class PaymentField extends FormComponent {
         : 'Add a valid test API key before you can preview the payment journey.'
       const govukError = createError(componentName, message)
       request.yar.flash(COMPONENT_STATE_ERROR, govukError, true)
-      return h.redirect(request.url.href).code(StatusCodes.SEE_OTHER)
+      return h
+        .redirect(`${request.url.pathname}${request.url.search}`)
+        .code(StatusCodes.SEE_OTHER)
     }
 
     const sessionData: PaymentSessionData = {

--- a/src/server/plugins/engine/pageControllers/QuestionPageController.ts
+++ b/src/server/plugins/engine/pageControllers/QuestionPageController.ts
@@ -422,7 +422,7 @@ export class QuestionPageController extends PageController {
       // Copy any URL params into the form state (if not already done so)
       if (await prefillStateFromQueryParameters(request, this)) {
         // Forward to same page without query string
-        return h.redirect(`${request.url.origin}${request.url.pathname}`)
+        return h.redirect(request.url.pathname)
       }
 
       const viewModel = this.getViewModel(request, context)
@@ -625,7 +625,7 @@ export class QuestionPageController extends PageController {
     return await selectedComponent.dispatcher(request, h, {
       component,
       controller: this,
-      sourceUrl: request.url.toString(),
+      sourceUrl: `${request.url.pathname}${request.url.search}`,
       actionArgs: args,
       isLive,
       isPreview


### PR DESCRIPTION
## Proposed change

Fixing issue that clashes with CDP when SSL terminates at the gateway and the internal address will appear without SSL, yet the browser sees it as having SSL (ie http vs https).

Jira ticket: (related to) https://eaflood.atlassian.net/browse/DF-927

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc. (documentation, build updates, etc)

## Checklist

- [ ] You have executed this code locally and it performs as expected.
- [ ] You have added tests to verify your code works.
- [ ] You have added code comments and JSDoc, where appropriate.
- [ ] There is no commented-out code.
- [ ] You have added developer docs in `README.md` and `docs/*` (where appropriate, e.g. new features).
- [ ] The tests are passing (`npm run test`).
- [ ] The linting checks are passing (`npm run lint`).
- [ ] The code has been formatted (`npm run format`).
