### PR TITLE
fix(DF-832): source GOV.UK Pay email from CYA confirmation field

### DIFF
--- a/src/server/plugins/engine/components/PaymentField.test.ts
+++ b/src/server/plugins/engine/components/PaymentField.test.ts
@@ -952,82 +952,14 @@ describe('PaymentField', () => {
   })
 
   describe('dispatcher with email prepopulation', () => {
-    it('should pass valid email to createPayment', async () => {
-      const emailDef = {
-        title: 'Payment with email',
+    it('should pass state.userConfirmationEmailAddress to createPayment', async () => {
+      const def = {
+        title: 'Payment',
         name: 'myPayment',
         type: ComponentType.PaymentField,
         options: {
           amount: 50,
-          description: 'Test payment',
-          emailField: 'userEmail'
-        }
-      } satisfies PaymentFieldComponent
-
-      const mockYarSet = jest.fn()
-      const mockRequest = {
-        server: {
-          plugins: {
-            'forms-engine-plugin': { baseUrl: 'base-url' }
-          }
-        },
-        yar: { set: mockYarSet }
-      } as unknown as FormRequestPayload
-      const mockH = {
-        redirect: jest
-          .fn()
-          .mockReturnValueOnce({ code: jest.fn().mockReturnValueOnce('ok') })
-      } as unknown as FormResponseToolkit
-      const args = {
-        controller: {
-          model: {
-            formId: 'formid',
-            basePath: 'base-path',
-            services: mockServices,
-            conditions: {}
-          },
-          getState: jest.fn().mockResolvedValueOnce({
-            $$__referenceNumber: 'ref-123',
-            userEmail: 'test@example.com'
-          })
-        },
-        component: emailDef,
-        sourceUrl: 'http://localhost:3009/test',
-        isLive: false,
-        isPreview: true
-      } as unknown as PaymentExternalArgs
-
-      // @ts-expect-error - partial mock
-      jest.mocked(postJson).mockResolvedValueOnce({
-        payload: {
-          state: { status: 'created' },
-          payment_id: 'pay-id',
-          _links: { next_url: { href: '/next' } }
-        }
-      })
-
-      await PaymentField.dispatcher(mockRequest, mockH, args)
-
-      // Verify createPayment was called with the email as the 7th argument
-      expect(postJson).toHaveBeenCalledWith(
-        expect.any(String),
-        expect.objectContaining({
-          payload: expect.objectContaining({
-            email: 'test@example.com'
-          })
-        })
-      )
-    })
-
-    it('should not pass email when emailField value is empty', async () => {
-      const emailDef = {
-        title: 'Payment with empty email',
-        name: 'myPayment',
-        type: ComponentType.PaymentField,
-        options: {
-          amount: 50,
-          description: 'Test payment',
-          emailField: 'userEmail'
+          description: 'Test payment'
         }
       } satisfies PaymentFieldComponent
 
@@ -1054,10 +986,10 @@ describe('PaymentField', () => {
           },
           getState: jest.fn().mockResolvedValueOnce({
             $$__referenceNumber: 'ref-123',
-            userEmail: ''
+            userConfirmationEmailAddress: 'cya@example.com'
           })
         },
-        component: emailDef,
+        component: def,
         sourceUrl: 'http://localhost:3009/test',
         isLive: false,
         isPreview: true
@@ -1074,7 +1006,133 @@ describe('PaymentField', () => {
 
       await PaymentField.dispatcher(mockRequest, mockH, args)
 
-      // Verify createPayment was called WITHOUT an email field
+      expect(postJson).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          payload: expect.objectContaining({
+            email: 'cya@example.com'
+          })
+        })
+      )
+    })
+
+    it('should not pass email when state.userConfirmationEmailAddress is missing', async () => {
+      const def = {
+        title: 'Payment',
+        name: 'myPayment',
+        type: ComponentType.PaymentField,
+        options: {
+          amount: 50,
+          description: 'Test payment'
+        }
+      } satisfies PaymentFieldComponent
+
+      const mockRequest = {
+        server: {
+          plugins: {
+            'forms-engine-plugin': { baseUrl: 'base-url' }
+          }
+        },
+        yar: { set: jest.fn() }
+      } as unknown as FormRequestPayload
+      const mockH = {
+        redirect: jest
+          .fn()
+          .mockReturnValueOnce({ code: jest.fn().mockReturnValueOnce('ok') })
+      } as unknown as FormResponseToolkit
+      const args = {
+        controller: {
+          model: {
+            formId: 'formid',
+            basePath: 'base-path',
+            services: mockServices,
+            conditions: {}
+          },
+          getState: jest.fn().mockResolvedValueOnce({
+            $$__referenceNumber: 'ref-123'
+          })
+        },
+        component: def,
+        sourceUrl: 'http://localhost:3009/test',
+        isLive: false,
+        isPreview: true
+      } as unknown as PaymentExternalArgs
+
+      // @ts-expect-error - partial mock
+      jest.mocked(postJson).mockResolvedValueOnce({
+        payload: {
+          state: { status: 'created' },
+          payment_id: 'pay-id',
+          _links: { next_url: { href: '/next' } }
+        }
+      })
+
+      await PaymentField.dispatcher(mockRequest, mockH, args)
+
+      expect(postJson).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          payload: expect.not.objectContaining({
+            email: expect.anything()
+          })
+        })
+      )
+    })
+
+    it('should not pass email when state.userConfirmationEmailAddress is not a string', async () => {
+      const def = {
+        title: 'Payment',
+        name: 'myPayment',
+        type: ComponentType.PaymentField,
+        options: {
+          amount: 50,
+          description: 'Test payment'
+        }
+      } satisfies PaymentFieldComponent
+
+      const mockRequest = {
+        server: {
+          plugins: {
+            'forms-engine-plugin': { baseUrl: 'base-url' }
+          }
+        },
+        yar: { set: jest.fn() }
+      } as unknown as FormRequestPayload
+      const mockH = {
+        redirect: jest
+          .fn()
+          .mockReturnValueOnce({ code: jest.fn().mockReturnValueOnce('ok') })
+      } as unknown as FormResponseToolkit
+      const args = {
+        controller: {
+          model: {
+            formId: 'formid',
+            basePath: 'base-path',
+            services: mockServices,
+            conditions: {}
+          },
+          getState: jest.fn().mockResolvedValueOnce({
+            $$__referenceNumber: 'ref-123',
+            userConfirmationEmailAddress: { not: 'a string' }
+          })
+        },
+        component: def,
+        sourceUrl: 'http://localhost:3009/test',
+        isLive: false,
+        isPreview: true
+      } as unknown as PaymentExternalArgs
+
+      // @ts-expect-error - partial mock
+      jest.mocked(postJson).mockResolvedValueOnce({
+        payload: {
+          state: { status: 'created' },
+          payment_id: 'pay-id',
+          _links: { next_url: { href: '/next' } }
+        }
+      })
+
+      await PaymentField.dispatcher(mockRequest, mockH, args)
+
       expect(postJson).toHaveBeenCalledWith(
         expect.any(String),
         expect.objectContaining({

--- a/src/server/plugins/engine/components/PaymentField.ts
+++ b/src/server/plugins/engine/components/PaymentField.ts
@@ -270,15 +270,10 @@ export class PaymentField extends FormComponent {
     const payCallbackUrl = `${baseUrl}/payment-callback?uuid=${uuid}`
     const paymentPageUrl = args.sourceUrl
 
-    // Prepopulate GOV.UK Pay email if emailField is configured.
-    // The referenced EmailAddressField validates with joi.string().email()
-    // at input time, so the value in state is already validated.
     let prefilledEmail: string | undefined
-    if (options.emailField) {
-      const emailValue = state[options.emailField]
-      if (typeof emailValue === 'string' && emailValue) {
-        prefilledEmail = emailValue
-      }
+    const userConfirmationEmail = state.userConfirmationEmailAddress
+    if (typeof userConfirmationEmail === 'string' && userConfirmationEmail) {
+      prefilledEmail = userConfirmationEmail
     }
 
     const amountInPence = Math.round(resolvedAmount * 100)


### PR DESCRIPTION
<!--
  Thank you for contributing to DXT! Please follow the instructions in the comment tags.
  Unless you have been instructed, do not delete any text in this template.
-->

## Proposed change

<!--
  Give a high-level description of the content of this pull request. No more than a couple of sentences.

  If you have consulted with the Defra Forms team prior to implementation, they will have provided you with an Azure DevOps work item number or (preferably) a link. Please include this.
-->

DF-832 requires the email pre-populated on GOV.UK Pay to come from the CYA confirmation email field, not a designer-configured form question. This change reads `state.userConfirmationEmailAddress` instead of `state[options.emailField]`.

Jira ticket:

## Type of change

<!--
  What type of change is this pull request? Mark the option with an X inside the brackets.
  If your change covers multiple categories, please split the pull request up to make it easier to review.
-->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc. (documentation, build updates, etc)

## Checklist

<!--
  Mark each completed item with an X, e.g. "[X] You have....".
  Feel free to chat to us on Slack if you have any questions.

  If you have not completed all of this, you are welcome to submit your pull request in a draft state
  to give us visibility and gather early feedback until it is ready for review.
-->

- [x] You have executed this code locally and it performs as expected.
- [x] You have added tests to verify your code works.
- [x] You have added code comments and JSDoc, where appropriate.
- [x] There is no commented-out code.
- [ ] You have added developer docs in \`README.md\` and \`docs/*\` (where appropriate, e.g. new features).
- [x] The tests are passing (\`npm run test\`).
- [x] The linting checks are passing (\`npm run lint\`).
- [x] The code has been formatted (\`npm run format\`).