### PR TITLE
Make the map support routes explicitly public

### DIFF
--- a/src/server/plugins/map/routes/index.js
+++ b/src/server/plugins/map/routes/index.js
@@ -73,6 +73,7 @@ function mapProxyRoute(options) {
       return response
     },
     options: {
+      auth: false,
       validate: {
         query: Joi.object()
           .keys({
@@ -119,6 +120,9 @@ function tileProxyRoute(options) {
         .response(payload)
         .type('application/x-protobuf')
         .header('Cache-Control', 'public, max-age=86400')
+    },
+    options: {
+      auth: false
     }
   }
 }
@@ -140,6 +144,7 @@ function geocodeProxyRoute(options) {
       return data
     },
     options: {
+      auth: false,
       validate: {
         query: Joi.object()
           .keys({
@@ -173,6 +178,7 @@ function reverseGeocodeProxyRoute(options) {
       return data
     },
     options: {
+      auth: false,
       validate: {
         query: Joi.object()
           .keys({
@@ -194,6 +200,7 @@ function mapStyleResourceRoutes() {
     method: 'GET',
     path: '/api/maps/vts/{path*}',
     options: {
+      auth: false,
       handler: {
         directory: {
           path: resolve(import.meta.dirname, './vts')
@@ -231,6 +238,7 @@ function getGeospatialCountries() {
       return countries
     },
     options: {
+      auth: false,
       validate: {
         query: Joi.object()
           .keys({


### PR DESCRIPTION
<!--
  Thank you for contributing to DXT! Please follow the instructions in the comment tags.
  Unless you have been instructed, do not delete any text in this template.
-->

## Proposed change

Explicitly make the map routes public to support non-account (AD only) users in forms-designer

<!--
  Give a high-level description of the content of this pull request. No more than a couple of sentences.

  If you have consulted with the Defra Forms team prior to implementation, they will have provided you with an Azure DevOps work item number or (preferably) a link. Please include this.
-->

Jira ticket: https://eaflood.atlassian.net/browse/DF-1041

## Type of change

<!--
  What type of change is this pull request? Mark the option with an X inside the brackets.
  If your change covers multiple categories, please split the pull request up to make it easier to review.
-->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc. (documentation, build updates, etc)

## Checklist

<!--
  Mark each completed item with an X, e.g. "[X] You have....".
  Feel free to chat to us on Slack if you have any questions.

  If you have not completed all of this, you are welcome to submit your pull request in a draft state
  to give us visibility and gather early feedback until it is ready for review.
-->

- [ ] You have executed this code locally and it performs as expected.
- [ ] You have added tests to verify your code works.
- [ ] You have added code comments and JSDoc, where appropriate.
- [ ] There is no commented-out code.
- [ ] You have added developer docs in `README.md` and `docs/*` (where appropriate, e.g. new features).
- [ ] The tests are passing (`npm run test`).
- [ ] The linting checks are passing (`npm run lint`).
- [ ] The code has been formatted (`npm run format`).
