### PR TITLE
Add min, max and length contraints to the GeospatialField

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@defra/forms-model": "^3.0.663",
+        "@defra/forms-model": "^3.0.667",
         "@defra/hapi-tracing": "^1.29.0",
         "@defra/interactive-map": "^0.0.22-alpha",
         "@elastic/ecs-pino-format": "^1.5.0",
@@ -3513,9 +3513,9 @@
       }
     },
     "node_modules/@defra/forms-model": {
-      "version": "3.0.663",
-      "resolved": "https://registry.npmjs.org/@defra/forms-model/-/forms-model-3.0.663.tgz",
-      "integrity": "sha512-hBP+Y/mt/5vI0IaqcYxT0ExpLUfTRngMORqgNjyVvymW8kEYeBMNK8mYQ92Qz4pz4GMKV8I460j3skxRlpNNaA==",
+      "version": "3.0.667",
+      "resolved": "https://registry.npmjs.org/@defra/forms-model/-/forms-model-3.0.667.tgz",
+      "integrity": "sha512-NLAj/qblpSZy3wR0VOfM8QDWqNj7qnfiZwj01cmfJLrpaVzpHJTkjyxO3Ki4JI8xAtk3p3knBWFNv3ayED56QQ==",
       "license": "OGL-UK-3.0",
       "dependencies": {
         "@joi/date": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
   },
   "license": "SEE LICENSE IN LICENSE",
   "dependencies": {
-    "@defra/forms-model": "^3.0.663",
+    "@defra/forms-model": "^3.0.667",
     "@defra/hapi-tracing": "^1.29.0",
     "@defra/interactive-map": "^0.0.22-alpha",
     "@elastic/ecs-pino-format": "^1.5.0",

--- a/src/server/plugins/engine/components/GeospatialField.test.ts
+++ b/src/server/plugins/engine/components/GeospatialField.test.ts
@@ -261,7 +261,7 @@ describe('GeospatialField', () => {
               value: getFormData([]),
               errors: [
                 expect.objectContaining({
-                  text: 'Example geospatial field must contain at least 1 items'
+                  text: 'Define at least 1 features'
                 })
               ]
             }
@@ -292,6 +292,171 @@ describe('GeospatialField', () => {
         ]
       },
       {
+        description: 'Required with min constraints',
+        component: {
+          title: 'Example geospatial field',
+          name: 'myComponent',
+          type: ComponentType.GeospatialField,
+          options: {
+            required: true
+          },
+          schema: {
+            min: 2
+          }
+        } satisfies GeospatialFieldComponent,
+        assertions: [
+          {
+            input: getFormData([]),
+            output: {
+              value: getFormData([]),
+              errors: [
+                expect.objectContaining({
+                  text: 'Define at least 2 features'
+                })
+              ]
+            }
+          },
+          {
+            input: getFormData(),
+            output: {
+              value: getFormData(),
+              errors: [
+                expect.objectContaining({
+                  text: 'Select example geospatial field'
+                })
+              ]
+            }
+          },
+          {
+            input: getFormData(validSingleState),
+            output: {
+              value: getFormData(validSingleState),
+              errors: [
+                expect.objectContaining({
+                  text: 'Define at least 2 features'
+                })
+              ]
+            }
+          },
+          {
+            input: getFormData(validState),
+            output: {
+              value: getFormData(validState)
+            }
+          }
+        ]
+      },
+      {
+        description: 'Required with max constraints',
+        component: {
+          title: 'Example geospatial field',
+          name: 'myComponent',
+          type: ComponentType.GeospatialField,
+          options: {
+            required: true
+          },
+          schema: {
+            max: 1
+          }
+        } satisfies GeospatialFieldComponent,
+        assertions: [
+          {
+            input: getFormData([]),
+            output: {
+              value: getFormData([]),
+              errors: [
+                expect.objectContaining({
+                  text: 'Define at least 1 features'
+                })
+              ]
+            }
+          },
+          {
+            input: getFormData(),
+            output: {
+              value: getFormData(),
+              errors: [
+                expect.objectContaining({
+                  text: 'Select example geospatial field'
+                })
+              ]
+            }
+          },
+          {
+            input: getFormData(validSingleState),
+            output: {
+              value: getFormData(validSingleState)
+            }
+          },
+          {
+            input: getFormData(validState),
+            output: {
+              value: getFormData(validState),
+              errors: [
+                expect.objectContaining({
+                  text: 'Only 1 features can be defined'
+                })
+              ]
+            }
+          }
+        ]
+      },
+      {
+        description: 'Required with exact length constraints',
+        component: {
+          title: 'Example geospatial field',
+          name: 'myComponent',
+          type: ComponentType.GeospatialField,
+          options: {
+            required: true
+          },
+          schema: {
+            length: 1
+          }
+        } satisfies GeospatialFieldComponent,
+        assertions: [
+          {
+            input: getFormData([]),
+            output: {
+              value: getFormData([]),
+              errors: [
+                expect.objectContaining({
+                  text: 'Define exactly 1 features'
+                })
+              ]
+            }
+          },
+          {
+            input: getFormData(),
+            output: {
+              value: getFormData(),
+              errors: [
+                expect.objectContaining({
+                  text: 'Select example geospatial field'
+                })
+              ]
+            }
+          },
+          {
+            input: getFormData(validSingleState),
+            output: {
+              value: getFormData(validSingleState)
+            }
+          },
+          {
+            input: getFormData(validState),
+            output: {
+              value: getFormData(validState),
+              errors: [
+                expect.objectContaining({
+                  text: 'Define exactly 1 features'
+                })
+              ]
+            }
+          }
+        ]
+      },
+      {
         description: 'Optional',
         component: {
           title: 'Example geospatial field',
@@ -307,14 +472,148 @@ describe('GeospatialField', () => {
             output: {
               value: getFormData([])
             }
+          }
+        ]
+      },
+      {
+        description: 'Optional with min constraints',
+        component: {
+          title: 'Example geospatial field',
+          name: 'myComponent',
+          type: ComponentType.GeospatialField,
+          options: {
+            required: false
+          },
+          schema: {
+            min: 2
+          }
+        } satisfies GeospatialFieldComponent,
+        assertions: [
+          {
+            input: getFormData([]),
+            output: {
+              value: getFormData([]),
+              errors: [
+                expect.objectContaining({
+                  text: 'Define at least 2 features'
+                })
+              ]
+            }
           },
           {
             input: getFormData(),
             output: {
-              value: getFormData(),
+              value: getFormData()
+            }
+          },
+          {
+            input: getFormData(validSingleState),
+            output: {
+              value: getFormData(validSingleState),
               errors: [
                 expect.objectContaining({
-                  text: 'Select example geospatial field'
+                  text: 'Define at least 2 features'
+                })
+              ]
+            }
+          },
+          {
+            input: getFormData(validState),
+            output: {
+              value: getFormData(validState)
+            }
+          }
+        ]
+      },
+      {
+        description: 'Optional with max constraints',
+        component: {
+          title: 'Example geospatial field',
+          name: 'myComponent',
+          type: ComponentType.GeospatialField,
+          options: {
+            required: false
+          },
+          schema: {
+            max: 1
+          }
+        } satisfies GeospatialFieldComponent,
+        assertions: [
+          {
+            input: getFormData([]),
+            output: {
+              value: getFormData([])
+            }
+          },
+          {
+            input: getFormData(),
+            output: {
+              value: getFormData()
+            }
+          },
+          {
+            input: getFormData(validSingleState),
+            output: {
+              value: getFormData(validSingleState)
+            }
+          },
+          {
+            input: getFormData(validState),
+            output: {
+              value: getFormData(validState),
+              errors: [
+                expect.objectContaining({
+                  text: 'Only 1 features can be defined'
+                })
+              ]
+            }
+          }
+        ]
+      },
+      {
+        description: 'Optional with exact length constraints',
+        component: {
+          title: 'Example geospatial field',
+          name: 'myComponent',
+          type: ComponentType.GeospatialField,
+          options: {
+            required: false
+          },
+          schema: {
+            length: 1
+          }
+        } satisfies GeospatialFieldComponent,
+        assertions: [
+          {
+            input: getFormData([]),
+            output: {
+              value: getFormData([]),
+              errors: [
+                expect.objectContaining({
+                  text: 'Define exactly 1 features'
+                })
+              ]
+            }
+          },
+          {
+            input: getFormData(),
+            output: {
+              value: getFormData()
+            }
+          },
+          {
+            input: getFormData(validSingleState),
+            output: {
+              value: getFormData(validSingleState)
+            }
+          },
+          {
+            input: getFormData(validState),
+            output: {
+              value: getFormData(validState),
+              errors: [
+                expect.objectContaining({
+                  text: 'Define exactly 1 features'
                 })
               ]
             }

--- a/src/server/plugins/engine/components/GeospatialField.ts
+++ b/src/server/plugins/engine/components/GeospatialField.ts
@@ -31,18 +31,21 @@ export class GeospatialField extends FormComponent {
 
     const { options } = def
 
-    let formSchema = getGeospatialSchema(options.countries?.at(0))
+    const formSchema = getGeospatialSchema(def)
       .label(this.label)
-      .required()
-
-    formSchema = formSchema.max(50)
-
-    if (options.required !== false) {
-      formSchema = formSchema.min(1)
-    }
+      .messages({
+        'array.min': messageTemplate.featuresMin as string,
+        'array.max': messageTemplate.featuresMax as string,
+        'array.length': messageTemplate.featuresLength as string
+      })
 
     this.formSchema = formSchema
     this.stateSchema = formSchema.default(null)
+
+    if (options.required === false) {
+      this.stateSchema = this.stateSchema.allow(null)
+    }
+
     this.options = options
   }
 

--- a/src/server/plugins/engine/components/helpers/geospatial.test.js
+++ b/src/server/plugins/engine/components/helpers/geospatial.test.js
@@ -1,9 +1,22 @@
-import { GeospatialFieldOptionsCountryEnum } from '@defra/forms-model'
+import {
+  ComponentType,
+  GeospatialFieldOptionsCountryEnum
+} from '@defra/forms-model'
 
 import { validState } from '~/src/server/plugins/engine/components/helpers/__stubs__/geospatial.js'
 import { getGeospatialSchema } from '~/src/server/plugins/engine/components/helpers/geospatial.js'
 
-const geospatialSchema = getGeospatialSchema()
+/**
+ * @type {import('@defra/forms-model').GeospatialFieldComponent}
+ */
+const geospatialComponent = {
+  name: 'geospatial',
+  title: 'Geospatial',
+  type: ComponentType.GeospatialField,
+  options: {}
+}
+
+const geospatialSchema = getGeospatialSchema(geospatialComponent)
 
 describe('Geospatial validation helpers', () => {
   test('it should not have errors for valid geojson object', () => {
@@ -39,8 +52,19 @@ describe('Geospatial validation helpers', () => {
   test('it should validate an empty array', () => {
     const result = geospatialSchema.validate('[]')
 
+    expect(result.error).toBeDefined()
+    expect(result.value).toBeUndefined()
+  })
+
+  test('it should validate an empty array when optional', () => {
+    const schema = getGeospatialSchema({
+      ...geospatialComponent,
+      options: { required: false }
+    })
+    const result = schema.validate('[]')
+
     expect(result.error).toBeUndefined()
-    expect(result.value).toEqual([])
+    expect(result.value).toBeUndefined()
   })
 
   test('it should not validate an empty object', () => {
@@ -58,9 +82,10 @@ describe('Geospatial validation helpers', () => {
   })
 
   test('it should be valid inside country bounds', () => {
-    const schema = getGeospatialSchema(
-      GeospatialFieldOptionsCountryEnum.England
-    )
+    const schema = getGeospatialSchema({
+      ...geospatialComponent,
+      options: { countries: [GeospatialFieldOptionsCountryEnum.England] }
+    })
 
     expect(schema.validate(validState).error).toBeUndefined()
     expect(schema.validate(validState.slice(1)).error).toBeUndefined()
@@ -69,9 +94,10 @@ describe('Geospatial validation helpers', () => {
   })
 
   test('it should be invalid outside country bounds', () => {
-    const schema = getGeospatialSchema(
-      GeospatialFieldOptionsCountryEnum.Scotland
-    )
+    const schema = getGeospatialSchema({
+      ...geospatialComponent,
+      options: { countries: [GeospatialFieldOptionsCountryEnum.Scotland] }
+    })
 
     expect(schema.validate(validState).error).toBeDefined()
     expect(schema.validate(validState.slice(1)).error).toBeDefined()
@@ -80,7 +106,7 @@ describe('Geospatial validation helpers', () => {
   })
 
   test('it should be valid with no country bounds', () => {
-    const schema = getGeospatialSchema()
+    const schema = getGeospatialSchema(geospatialComponent)
 
     expect(schema.validate(validState).error).toBeUndefined()
   })

--- a/src/server/plugins/engine/components/helpers/geospatial.ts
+++ b/src/server/plugins/engine/components/helpers/geospatial.ts
@@ -1,5 +1,6 @@
 import {
   GeospatialFieldOptionsCountryEnum,
+  type GeospatialFieldComponent,
   type GeospatialFieldOptionsCountry
 } from '@defra/forms-model'
 import Bourne from '@hapi/bourne'
@@ -31,7 +32,8 @@ const Joi = JoiBase.extend({
     from: 'string',
     method(value, helpers) {
       if (typeof value === 'string') {
-        if (value.trim() === '') {
+        const trimmed = value.trim()
+        if (trimmed === '' || trimmed === '[]') {
           return {
             value: undefined
           }
@@ -96,14 +98,48 @@ const featureSchema = Joi.object<Feature>().keys({
   geometry: featureGeometrySchema
 })
 
-const geospatialSchema = Joi.array<Feature[]>()
-  .items(featureSchema)
-  .unique('id')
-  .required()
+function applySchemaConstraints(
+  schema: JoiBase.ArraySchema<Feature[]>,
+  def: GeospatialFieldComponent
+) {
+  const { options, schema: constraints } = def
+  const isOptional = options.required === false
 
-export function getGeospatialSchema(country?: GeospatialFieldOptionsCountry) {
+  if (typeof constraints?.length === 'number') {
+    schema = schema.length(constraints.length)
+  } else {
+    if (typeof constraints?.min === 'number') {
+      schema = schema.min(constraints.min)
+    } else if (!isOptional) {
+      schema = schema.min(1)
+    }
+
+    schema = schema.max(
+      typeof constraints?.max === 'number' ? constraints.max : 50
+    )
+  }
+
+  if (isOptional) {
+    schema = schema.optional()
+  } else {
+    schema = schema.required()
+  }
+
+  return schema
+}
+
+export function getGeospatialSchema(
+  def: GeospatialFieldComponent
+): JoiBase.ArraySchema<Feature[]> {
+  const { options = {} } = def
+  const country: GeospatialFieldOptionsCountry | undefined =
+    options.countries?.at(0)
+
   if (!country) {
-    return geospatialSchema
+    return applySchemaConstraints(
+      Joi.array<Feature[]>().items(featureSchema).unique('id'),
+      def
+    )
   }
 
   const validateCountryBounds: CustomValidator = (value, helpers) => {
@@ -128,10 +164,12 @@ export function getGeospatialSchema(country?: GeospatialFieldOptionsCountry) {
     return value
   }
 
-  return Joi.array<Feature[]>()
-    .items(featureSchema.custom(validateCountryBounds))
-    .unique('id')
-    .required()
+  return applySchemaConstraints(
+    Joi.array<Feature[]>()
+      .items(featureSchema.custom(validateCountryBounds))
+      .unique('id'),
+    def
+  )
 }
 
 /**

--- a/src/server/plugins/engine/pageControllers/validationOptions.ts
+++ b/src/server/plugins/engine/pageControllers/validationOptions.ts
@@ -64,7 +64,10 @@ export const messageTemplate: Record<string, JoiExpression> = {
   dateMax: '{{#title}} must be the same as or before {{#limit}}',
   arrayMin: 'Select at least {{#limit}} options from the list',
   arrayMax: 'Only {{#limit}} can be selected from the list',
-  arrayLength: 'Select only {{#limit}} options from the list'
+  arrayLength: 'Select only {{#limit}} options from the list',
+  featuresMin: 'Define at least {{#limit}} features',
+  featuresMax: 'Only {{#limit}} features can be defined',
+  featuresLength: 'Define exactly {{#limit}} features'
 }
 
 export const messages: LanguageMessagesExt = {


### PR DESCRIPTION
<!--
  Thank you for contributing to DXT! Please follow the instructions in the comment tags.
  Unless you have been instructed, do not delete any text in this template.
-->

## Proposed change

Add min, max and exact length schema constraints to the GeospatialField.
Depends on https://github.com/DEFRA/forms-designer/pull/1442

<!--
  Give a high-level description of the content of this pull request. No more than a couple of sentences.

  If you have consulted with the Defra Forms team prior to implementation, they will have provided you with an Azure DevOps work item number or (preferably) a link. Please include this.
-->

Jira ticket: https://eaflood.atlassian.net/browse/DF-1086

## Type of change

<!--
  What type of change is this pull request? Mark the option with an X inside the brackets.
  If your change covers multiple categories, please split the pull request up to make it easier to review.
-->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc. (documentation, build updates, etc)

## Checklist

<!--
  Mark each completed item with an X, e.g. "[X] You have....".
  Feel free to chat to us on Slack if you have any questions.

  If you have not completed all of this, you are welcome to submit your pull request in a draft state
  to give us visibility and gather early feedback until it is ready for review.
-->

- [x] You have executed this code locally and it performs as expected.
- [x] You have added tests to verify your code works.
- [x] You have added code comments and JSDoc, where appropriate.
- [x] There is no commented-out code.
- [x] You have added developer docs in `README.md` and `docs/*` (where appropriate, e.g. new features).
- [x] The tests are passing (`npm run test`).
- [x] The linting checks are passing (`npm run lint`).
- [x] The code has been formatted (`npm run format`).
