### PR TITLE
Fix/df 1098: Short-term fix of missing payment details

### DIFF
--- a/src/server/plugins/engine/models/FormModel.test.ts
+++ b/src/server/plugins/engine/models/FormModel.test.ts
@@ -753,7 +753,9 @@ describe('FormModel - Joined Conditions', () => {
       const page = definition.pages[0] as PageQuestion
       page.components.push(extraPaymentComponent)
 
-      expect(() => new FormModel(definition, { basePath: 'test' })).toThrow('Invalid form definition: Only one payment question is allowed per form')
+      expect(() => new FormModel(definition, { basePath: 'test' })).toThrow(
+        'Invalid form definition: Only one payment question is allowed per form'
+      )
     })
   })
 })

--- a/src/server/plugins/engine/models/FormModel.test.ts
+++ b/src/server/plugins/engine/models/FormModel.test.ts
@@ -1,8 +1,11 @@
 import {
+  ComponentType,
   SchemaVersion,
   formDefinitionSchema,
   formDefinitionV2Schema,
-  type FormDefinition
+  type ComponentDef,
+  type FormDefinition,
+  type PageQuestion
 } from '@defra/forms-model'
 
 import { todayAsDateOnly } from '~/src/server/plugins/engine/date-helper.js'
@@ -16,6 +19,7 @@ import conditionsListDefinition from '~/test/form/definitions/conditions-list.js
 import relativeDatesDefinition from '~/test/form/definitions/conditions-relative-dates-v2.js'
 import fieldsRequiredDefinition from '~/test/form/definitions/fields-required.js'
 import joinedConditionsDefinition from '~/test/form/definitions/joined-conditions-simple-v2.js'
+import paymentDefinition from '~/test/form/definitions/payment.js'
 
 jest.mock('~/src/server/plugins/engine/date-helper.ts')
 
@@ -720,6 +724,36 @@ describe('FormModel - Joined Conditions', () => {
       // V2 should not find by name
       expect(model.getSection('personal')).toBeUndefined()
       expect(model.getSection('nonexistent')).toBeUndefined()
+    })
+  })
+
+  describe('moreThanOnePaymentQuestion', () => {
+    it('should return false if no payment questions', () => {
+      const model = new FormModel(definition, { basePath: 'test' })
+      expect(model.moreThanOnePaymentQuestion()).toBe(false)
+    })
+
+    it('should return false if only one payment question', () => {
+      const definition = {
+        ...paymentDefinition
+      }
+
+      const model = new FormModel(definition, { basePath: 'test' })
+      expect(model.moreThanOnePaymentQuestion()).toBe(false)
+    })
+
+    it('should throw if more than one payment questions', () => {
+      const definition = {
+        ...paymentDefinition
+      }
+      const extraPaymentComponent = {
+        type: ComponentType.PaymentField,
+        name: 'paymentField'
+      } as ComponentDef
+      const page = definition.pages[0] as PageQuestion
+      page.components.push(extraPaymentComponent)
+
+      expect(() => new FormModel(definition, { basePath: 'test' })).toThrow('Invalid form definition: Only one payment question is allowed per form')
     })
   })
 })

--- a/src/server/plugins/engine/models/FormModel.ts
+++ b/src/server/plugins/engine/models/FormModel.ts
@@ -9,6 +9,7 @@ import {
   formDefinitionV2Schema,
   generateConditionAlias,
   hasComponents,
+  hasComponentsEvenIfNoNext,
   hasRepeater,
   isConditionWrapperV2,
   yesNoListId,
@@ -158,6 +159,11 @@ export class FormModel {
     this.conditions = {}
     this.services = services
     this.controllers = controllers
+
+    // Assert that there is only one payment question (if any)
+    if (this.moreThanOnePaymentQuestion()) {
+      throw new Error('Invalid form definition: Only one payment question is allowed per form')
+    }
 
     this.pageDefMap = new Map(def.pages.map((page) => [page.path, page]))
     this.listDefMap = new Map(def.lists.map((list) => [list.name, list]))
@@ -542,6 +548,20 @@ export class FormModel {
     return this.def.conditions
       .filter(isConditionWrapperV2)
       .find((condition) => condition.id === conditionId)
+  }
+
+  /**
+   * Checks that only one payment field exists (if any payments fields exist)
+   */
+  moreThanOnePaymentQuestion() {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    if (!this.def) {
+      return false
+    }
+    const numOfPaymentFields = this.def.pages
+          .flatMap((page) => hasComponentsEvenIfNoNext(page) ? page.components : [])
+          .filter((comp) => comp.type === ComponentType.PaymentField).length
+    return numOfPaymentFields > 1
   }
 }
 

--- a/src/server/plugins/engine/models/FormModel.ts
+++ b/src/server/plugins/engine/models/FormModel.ts
@@ -162,7 +162,9 @@ export class FormModel {
 
     // Assert that there is only one payment question (if any)
     if (this.moreThanOnePaymentQuestion()) {
-      throw new Error('Invalid form definition: Only one payment question is allowed per form')
+      throw new Error(
+        'Invalid form definition: Only one payment question is allowed per form'
+      )
     }
 
     this.pageDefMap = new Map(def.pages.map((page) => [page.path, page]))
@@ -559,8 +561,10 @@ export class FormModel {
       return false
     }
     const numOfPaymentFields = this.def.pages
-          .flatMap((page) => hasComponentsEvenIfNoNext(page) ? page.components : [])
-          .filter((comp) => comp.type === ComponentType.PaymentField).length
+      .flatMap((page) =>
+        hasComponentsEvenIfNoNext(page) ? page.components : []
+      )
+      .filter((comp) => comp.type === ComponentType.PaymentField).length
     return numOfPaymentFields > 1
   }
 }

--- a/src/server/plugins/engine/models/FormModel.ts
+++ b/src/server/plugins/engine/models/FormModel.ts
@@ -556,10 +556,6 @@ export class FormModel {
    * Checks that only one payment field exists (if any payments fields exist)
    */
   moreThanOnePaymentQuestion() {
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-    if (!this.def) {
-      return false
-    }
     const numOfPaymentFields = this.def.pages
       .flatMap((page) =>
         hasComponentsEvenIfNoNext(page) ? page.components : []

--- a/src/server/plugins/engine/outputFormatters/human/v1.payment.test.ts
+++ b/src/server/plugins/engine/outputFormatters/human/v1.payment.test.ts
@@ -82,7 +82,8 @@ describe('v1 human formatter', () => {
 
     const itemsPayment = getFormSubmissionData(
       summaryViewModelPayment.context,
-      summaryViewModelPayment.details
+      summaryViewModelPayment.details,
+      modelPayment
     )
 
     it('should add payment details', () => {

--- a/src/server/plugins/engine/outputFormatters/human/v1.test.ts
+++ b/src/server/plugins/engine/outputFormatters/human/v1.test.ts
@@ -70,7 +70,8 @@ describe('v1 human formatter', () => {
 
   const items = getFormSubmissionData(
     summaryViewModel.context,
-    summaryViewModel.details
+    summaryViewModel.details,
+    model
   )
 
   describe('getPersonalisation', () => {

--- a/src/server/plugins/engine/outputFormatters/machine/v2.payment.test.ts
+++ b/src/server/plugins/engine/outputFormatters/machine/v2.payment.test.ts
@@ -79,7 +79,8 @@ const summaryViewModel = controller.getSummaryViewModel(request, context)
 
 const items = getFormSubmissionData(
   summaryViewModel.context,
-  summaryViewModel.details
+  summaryViewModel.details,
+  model
 )
 
 describe('getPersonalisation', () => {

--- a/src/server/plugins/engine/outputFormatters/machine/v2.test.ts
+++ b/src/server/plugins/engine/outputFormatters/machine/v2.test.ts
@@ -280,7 +280,8 @@ describe('getPersonalisation', () => {
 
     const items = getFormSubmissionData(
       summaryViewModel.context,
-      summaryViewModel.details
+      summaryViewModel.details,
+      model
     )
 
     const body = format(context, items, model, submitResponse, formStatus)

--- a/src/server/plugins/engine/pageControllers/SummaryPageController.test.ts
+++ b/src/server/plugins/engine/pageControllers/SummaryPageController.test.ts
@@ -356,12 +356,13 @@ describe('SummaryPageController - Payment (DF-832)', () => {
           } as FormSubmissionState)
 
       const outputSubmit = jest.fn()
+      const formSubmissionSubmit = jest.fn()
 
       model.services = {
         ...model.services,
         formSubmissionService: {
           ...model.services.formSubmissionService,
-          submit: jest.fn().mockResolvedValue({ data: { reference: 'r' } })
+          submit: formSubmissionSubmit.mockResolvedValue({ data: { reference: 'r' } })
         },
         outputService: {
           ...model.services.outputService,
@@ -387,7 +388,7 @@ describe('SummaryPageController - Payment (DF-832)', () => {
         contact: { online: { url: '/help' } }
       } as unknown as Parameters<typeof submitForm>[1]
 
-      return { request, context, viewModel, formMetadata, outputSubmit }
+      return { request, context, viewModel, formMetadata, outputSubmit, formSubmissionSubmit }
     }
 
     it('re-throws as PaymentSubmissionError when outputService fails and a payment has been captured', async () => {
@@ -427,6 +428,45 @@ describe('SummaryPageController - Payment (DF-832)', () => {
           'notify@example.com'
         )
       ).rejects.toBe(err)
+    })
+
+    it('submits with correct payload', async () => {
+      const { request, context, viewModel, formMetadata, outputSubmit, formSubmissionSubmit } =
+        buildSubmitHarness({ captured: true })
+
+      await submitForm(
+        context,
+        formMetadata,
+        request,
+        viewModel,
+        model,
+        'notify@example.com'
+      )
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      const paymentCall = formSubmissionSubmit.mock.calls[0][0]
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      const paymentItems = paymentCall.main as unknown as { name: string, title: string, value: string }[]
+      expect(paymentItems).toHaveLength(4)
+      expect(paymentItems[0]).toEqual({
+        name: 'paymentField_paymentDescription',
+        title: 'Payment description',
+        value: 'Test payment'
+      })
+      expect(paymentItems[1]).toEqual({
+        name: 'paymentField_paymentAmount',
+          title: 'Payment amount',
+          value: '£99.00'
+      })
+      expect(paymentItems[2]).toEqual({
+        name: 'paymentField_paymentReference',
+          title: 'Payment reference',
+          value: 'ref-1'
+      })
+      expect(paymentItems[3]).toEqual({
+        name: 'paymentField_paymentDate',
+          title: 'Payment date',
+          value: ''
+      })
     })
   })
 })

--- a/src/server/plugins/engine/pageControllers/SummaryPageController.test.ts
+++ b/src/server/plugins/engine/pageControllers/SummaryPageController.test.ts
@@ -362,7 +362,9 @@ describe('SummaryPageController - Payment (DF-832)', () => {
         ...model.services,
         formSubmissionService: {
           ...model.services.formSubmissionService,
-          submit: formSubmissionSubmit.mockResolvedValue({ data: { reference: 'r' } })
+          submit: formSubmissionSubmit.mockResolvedValue({
+            data: { reference: 'r' }
+          })
         },
         outputService: {
           ...model.services.outputService,
@@ -388,7 +390,14 @@ describe('SummaryPageController - Payment (DF-832)', () => {
         contact: { online: { url: '/help' } }
       } as unknown as Parameters<typeof submitForm>[1]
 
-      return { request, context, viewModel, formMetadata, outputSubmit, formSubmissionSubmit }
+      return {
+        request,
+        context,
+        viewModel,
+        formMetadata,
+        outputSubmit,
+        formSubmissionSubmit
+      }
     }
 
     it('re-throws as PaymentSubmissionError when outputService fails and a payment has been captured', async () => {
@@ -431,8 +440,13 @@ describe('SummaryPageController - Payment (DF-832)', () => {
     })
 
     it('submits with correct payload', async () => {
-      const { request, context, viewModel, formMetadata, formSubmissionSubmit } =
-        buildSubmitHarness({ captured: true })
+      const {
+        request,
+        context,
+        viewModel,
+        formMetadata,
+        formSubmissionSubmit
+      } = buildSubmitHarness({ captured: true })
 
       await submitForm(
         context,
@@ -445,7 +459,11 @@ describe('SummaryPageController - Payment (DF-832)', () => {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       const paymentCall = formSubmissionSubmit.mock.calls[0][0]
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      const paymentItems = paymentCall.main as unknown as { name: string, title: string, value: string }[]
+      const paymentItems = paymentCall.main as unknown as {
+        name: string
+        title: string
+        value: string
+      }[]
       expect(paymentItems).toHaveLength(4)
       expect(paymentItems[0]).toEqual({
         name: 'paymentField_paymentDescription',
@@ -454,18 +472,18 @@ describe('SummaryPageController - Payment (DF-832)', () => {
       })
       expect(paymentItems[1]).toEqual({
         name: 'paymentField_paymentAmount',
-          title: 'Payment amount',
-          value: '£99.00'
+        title: 'Payment amount',
+        value: '£99.00'
       })
       expect(paymentItems[2]).toEqual({
         name: 'paymentField_paymentReference',
-          title: 'Payment reference',
-          value: 'ref-1'
+        title: 'Payment reference',
+        value: 'ref-1'
       })
       expect(paymentItems[3]).toEqual({
         name: 'paymentField_paymentDate',
-          title: 'Payment date',
-          value: ''
+        title: 'Payment date',
+        value: ''
       })
     })
   })

--- a/src/server/plugins/engine/pageControllers/SummaryPageController.test.ts
+++ b/src/server/plugins/engine/pageControllers/SummaryPageController.test.ts
@@ -431,7 +431,7 @@ describe('SummaryPageController - Payment (DF-832)', () => {
     })
 
     it('submits with correct payload', async () => {
-      const { request, context, viewModel, formMetadata, outputSubmit, formSubmissionSubmit } =
+      const { request, context, viewModel, formMetadata, formSubmissionSubmit } =
         buildSubmitHarness({ captured: true })
 
       await submitForm(

--- a/src/server/plugins/engine/pageControllers/SummaryPageController.ts
+++ b/src/server/plugins/engine/pageControllers/SummaryPageController.ts
@@ -433,7 +433,8 @@ export async function submitForm(
 
   const items = getFormSubmissionData(
     summaryViewModel.context,
-    summaryViewModel.details
+    summaryViewModel.details,
+    model
   )
 
   try {
@@ -531,11 +532,10 @@ function submitData(
     main: buildMainRecords(items),
     repeaters: buildRepeaterRecords(items)
   }
-
   return submit(payload)
 }
 
-export function getFormSubmissionData(context: FormContext, details: Detail[]) {
+export function getFormSubmissionData(context: FormContext, details: Detail[], model: FormModel) {
   const items = context.relevantPages
     .map(({ href }) =>
       details.flatMap(({ items }) =>
@@ -544,7 +544,7 @@ export function getFormSubmissionData(context: FormContext, details: Detail[]) {
     )
     .flat()
 
-  const paymentItems = getPaymentFieldItems(context)
+  const paymentItems = getPaymentFieldItems(context, model)
 
   return [...items, ...paymentItems]
 }
@@ -553,10 +553,10 @@ export function getFormSubmissionData(context: FormContext, details: Detail[]) {
  * Gets DetailItems for PaymentField components
  * PaymentField is excluded from summaryDetails for UI but needs to be in submission data
  */
-function getPaymentFieldItems(context: FormContext): DetailItemField[] {
+function getPaymentFieldItems(context: FormContext, model: FormModel): DetailItemField[] {
   const items: DetailItemField[] = []
 
-  for (const page of context.relevantPages) {
+  for (const page of model.pages) {
     for (const field of page.collection.fields) {
       if (field instanceof PaymentField) {
         items.push({

--- a/src/server/plugins/engine/pageControllers/SummaryPageController.ts
+++ b/src/server/plugins/engine/pageControllers/SummaryPageController.ts
@@ -535,7 +535,11 @@ function submitData(
   return submit(payload)
 }
 
-export function getFormSubmissionData(context: FormContext, details: Detail[], model: FormModel) {
+export function getFormSubmissionData(
+  context: FormContext,
+  details: Detail[],
+  model: FormModel
+) {
   const items = context.relevantPages
     .map(({ href }) =>
       details.flatMap(({ items }) =>
@@ -553,7 +557,10 @@ export function getFormSubmissionData(context: FormContext, details: Detail[], m
  * Gets DetailItems for PaymentField components
  * PaymentField is excluded from summaryDetails for UI but needs to be in submission data
  */
-function getPaymentFieldItems(context: FormContext, model: FormModel): DetailItemField[] {
+function getPaymentFieldItems(
+  context: FormContext,
+  model: FormModel
+): DetailItemField[] {
   const items: DetailItemField[] = []
 
   for (const page of model.pages) {

--- a/src/server/plugins/engine/routes/questions.ts
+++ b/src/server/plugins/engine/routes/questions.ts
@@ -59,7 +59,7 @@ async function handleHttpEvent(
   // TODO: Update structured data POST payload with when helper
   // is updated to removing the dependency on `SummaryViewModel` etc.
   const viewModel = new SummaryViewModel(request, page, context)
-  const items = getFormSubmissionData(viewModel.context, viewModel.details)
+  const items = getFormSubmissionData(viewModel.context, viewModel.details, model)
 
   // @ts-expect-error - function signature will be refactored in the next iteration of the formatter
   const payload = format(context, items, model, undefined, undefined)

--- a/src/server/plugins/engine/routes/questions.ts
+++ b/src/server/plugins/engine/routes/questions.ts
@@ -59,7 +59,11 @@ async function handleHttpEvent(
   // TODO: Update structured data POST payload with when helper
   // is updated to removing the dependency on `SummaryViewModel` etc.
   const viewModel = new SummaryViewModel(request, page, context)
-  const items = getFormSubmissionData(viewModel.context, viewModel.details, model)
+  const items = getFormSubmissionData(
+    viewModel.context,
+    viewModel.details,
+    model
+  )
 
   // @ts-expect-error - function signature will be refactored in the next iteration of the formatter
   const payload = format(context, items, model, undefined, undefined)


### PR DESCRIPTION
<!--
  Thank you for contributing to DXT! Please follow the instructions in the comment tags.
  Unless you have been instructed, do not delete any text in this template.
-->

## Proposed change
Payment details are missing from the submission payload. This is a short-term fix to add them.

<!--
  Give a high-level description of the content of this pull request. No more than a couple of sentences.

  If you have consulted with the Defra Forms team prior to implementation, they will have provided you with an Azure DevOps work item number or (preferably) a link. Please include this.
-->

Jira ticket: [DF-1098](https://eaflood.atlassian.net/browse/DF-1098)

## Type of change

<!--
  What type of change is this pull request? Mark the option with an X inside the brackets.
  If your change covers multiple categories, please split the pull request up to make it easier to review.
-->

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc. (documentation, build updates, etc)

## Checklist

<!--
  Mark each completed item with an X, e.g. "[X] You have....".
  Feel free to chat to us on Slack if you have any questions.

  If you have not completed all of this, you are welcome to submit your pull request in a draft state
  to give us visibility and gather early feedback until it is ready for review.
-->

- [X] You have executed this code locally and it performs as expected.
- [X] You have added tests to verify your code works.
- [X] You have added code comments and JSDoc, where appropriate.
- [X] There is no commented-out code.
- [X] You have added developer docs in `README.md` and `docs/*` (where appropriate, e.g. new features).
- [X] The tests are passing (`npm run test`).
- [X] The linting checks are passing (`npm run lint`).
- [X] The code has been formatted (`npm run format`).


[DF-1098]: https://eaflood.atlassian.net/browse/DF-1098?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ