### PR TITLE
Docs: document viewName override for pages

### DIFF
--- a/docs/features/code-based/page-controllers.md
+++ b/docs/features/code-based/page-controllers.md
@@ -63,10 +63,27 @@ Both are imported from `@defra/forms-engine-plugin/controllers/<ClassName>.js`.
 
 ## Examples
 
+- [Changing the Nunjucks template](#changing-the-nunjucks-template)
 - [Fetching data for the view model](#fetching-data-for-the-view-model)
 - [Intercepting the GET handler](#intercepting-the-get-handler)
 - [Writing to state on POST](#writing-to-state-on-post)
 - [Display-only page (no form components)](#display-only-page-no-form-components)
+
+### Changing the Nunjucks template
+
+To render a different Nunjucks template without changing any handler logic, declare `viewName` as a class property. No handler overrides are needed — all standard GET and POST behaviour (validation, state, routing, error display) runs unchanged:
+
+```ts
+import { QuestionPageController } from '@defra/forms-engine-plugin/controllers/QuestionPageController.js'
+
+class CustomViewPageController extends QuestionPageController {
+  viewName = 'my-custom-page'
+}
+```
+
+The template receives the same view model as the default `index` template. See [Templates and views](./page-views.md) to configure Nunjucks to resolve your template file.
+
+> **Note:** A `view` property on the page definition in your form JSON also overrides `viewName` — but that approach does not require a custom controller at all. Use the class property when you want every page using this controller to share the same template.
 
 ### Fetching data for the view model
 


### PR DESCRIPTION
Adds a 'Changing the Nunjucks template' example showing how to override viewName without writing any handler logic, covering the minimal use case that was previously undocumented.

<!--
  Thank you for contributing to DXT! Please follow the instructions in the comment tags.
  Unless you have been instructed, do not delete any text in this template.
-->

## Proposed change

<!--
  Give a high-level description of the content of this pull request. No more than a couple of sentences.

  If you have consulted with the Defra Forms team prior to implementation, they will have provided you with an Azure DevOps work item number or (preferably) a link. Please include this.
-->

Jira ticket:

## Type of change

<!--
  What type of change is this pull request? Mark the option with an X inside the brackets.
  If your change covers multiple categories, please split the pull request up to make it easier to review.
-->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc. (documentation, build updates, etc)

## Checklist

<!--
  Mark each completed item with an X, e.g. "[X] You have....".
  Feel free to chat to us on Slack if you have any questions.

  If you have not completed all of this, you are welcome to submit your pull request in a draft state
  to give us visibility and gather early feedback until it is ready for review.
-->

- [x] You have executed this code locally and it performs as expected.
- [x] You have added tests to verify your code works.
- [x] You have added code comments and JSDoc, where appropriate.
- [x] There is no commented-out code.
- [x] You have added developer docs in `README.md` and `docs/*` (where appropriate, e.g. new features).
- [x] The tests are passing (`npm run test`).
- [x] The linting checks are passing (`npm run lint`).
- [x] The code has been formatted (`npm run format`).
