### PR TITLE
DF-951: MonthYearField to support absolute date range options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@defra/forms-model": "^3.0.676",
+        "@defra/forms-model": "^3.0.678",
         "@defra/hapi-tracing": "^1.29.0",
         "@defra/interactive-map": "^0.0.22-alpha",
         "@elastic/ecs-pino-format": "^1.5.0",
@@ -3516,9 +3516,9 @@
       }
     },
     "node_modules/@defra/forms-model": {
-      "version": "3.0.676",
-      "resolved": "https://registry.npmjs.org/@defra/forms-model/-/forms-model-3.0.676.tgz",
-      "integrity": "sha512-YH0nYkFVTi6PE6xWKEDYK95aT1dJCSIpxkDx5QfkNSkEQqET6nf4o4QYsYISehJl5XSPwAZVHn36RyXCyYhqFg==",
+      "version": "3.0.678",
+      "resolved": "https://registry.npmjs.org/@defra/forms-model/-/forms-model-3.0.678.tgz",
+      "integrity": "sha512-J7FkKLZIMpJk6Y6VihFx9jmODWnoSYONFx+khSdZIAUqWh2dg6S4ikfDszSioW0sq1owndBYolvjuVeaLhg1dw==",
       "license": "OGL-UK-3.0",
       "dependencies": {
         "@joi/date": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
   },
   "license": "SEE LICENSE IN LICENSE",
   "dependencies": {
-    "@defra/forms-model": "^3.0.676",
+    "@defra/forms-model": "^3.0.678",
     "@defra/hapi-tracing": "^1.29.0",
     "@defra/interactive-map": "^0.0.22-alpha",
     "@elastic/ecs-pino-format": "^1.5.0",

--- a/src/server/plugins/engine/components/MonthYearField.test.ts
+++ b/src/server/plugins/engine/components/MonthYearField.test.ts
@@ -1,5 +1,5 @@
 import { ComponentType, type MonthYearFieldComponent } from '@defra/forms-model'
-import { startOfDay } from 'date-fns'
+import { addMonths, format, startOfDay, startOfMonth } from 'date-fns'
 
 import { ComponentCollection } from '~/src/server/plugins/engine/components/ComponentCollection.js'
 import {
@@ -401,6 +401,13 @@ describe('MonthYearField', () => {
 
   describe('Validation', () => {
     const date = new Date('2001-01-01')
+    const today = startOfDay(new Date())
+    const thisMonth = startOfMonth(today)
+
+    const OneMonthInPast = addMonths(thisMonth, -1)
+    const TwoMonthsInPast = addMonths(thisMonth, -2)
+    const OneMonthInFuture = addMonths(thisMonth, 1)
+    const TwoMonthsInFuture = addMonths(thisMonth, 2)
 
     describe.each([
       {
@@ -514,6 +521,62 @@ describe('MonthYearField', () => {
                 })
               ]
             }
+          }
+        ]
+      },
+      {
+        description: 'Earliest month/year option',
+        component: {
+          title: 'Example month/year field',
+          name: 'myComponent',
+          type: ComponentType.MonthYearField,
+          options: {
+            earliestMonthYear: format(OneMonthInPast, 'yyyy-MM')
+          }
+        } satisfies MonthYearFieldComponent,
+        assertions: [
+          {
+            input: getFormData(TwoMonthsInPast),
+            output: {
+              value: getFormData(TwoMonthsInPast),
+              errors: [
+                expect.objectContaining({
+                  text: `Example month/year field must be the same as or after ${format(OneMonthInPast, 'd MMMM yyyy')}`
+                })
+              ]
+            }
+          },
+          {
+            input: getFormData(today),
+            output: { value: getFormData(today) }
+          }
+        ]
+      },
+      {
+        description: 'Latest month/year option',
+        component: {
+          title: 'Example month/year field',
+          name: 'myComponent',
+          type: ComponentType.MonthYearField,
+          options: {
+            latestMonthYear: format(OneMonthInFuture, 'yyyy-MM')
+          }
+        } satisfies MonthYearFieldComponent,
+        assertions: [
+          {
+            input: getFormData(TwoMonthsInFuture),
+            output: {
+              value: getFormData(TwoMonthsInFuture),
+              errors: [
+                expect.objectContaining({
+                  text: `Example month/year field must be the same as or before ${format(OneMonthInFuture, 'd MMMM yyyy')}`
+                })
+              ]
+            }
+          },
+          {
+            input: getFormData(today),
+            output: { value: getFormData(today) }
           }
         ]
       },

--- a/src/server/plugins/engine/components/MonthYearField.ts
+++ b/src/server/plugins/engine/components/MonthYearField.ts
@@ -1,5 +1,5 @@
 import { ComponentType, type MonthYearFieldComponent } from '@defra/forms-model'
-import { format, isValid } from 'date-fns'
+import { format, isValid, parse } from 'date-fns'
 import {
   type Context,
   type CustomValidator,
@@ -257,6 +257,34 @@ export function getValidatorMonthYear(component: MonthYearField) {
       return options.required !== false
         ? helpers.error('object.required', context)
         : payload
+    }
+
+    const date = parse(
+      `${values.year}-${values.month}-01`,
+      'yyyy-MM-dd',
+      new Date()
+    )
+
+    if (!isValid(date)) {
+      return helpers.error('date.format', context)
+    }
+
+    // Minimum date from today
+    const earliestDate = options.earliestMonthYear
+      ? new Date(`${options.earliestMonthYear}-01`)
+      : undefined
+
+    if (earliestDate && date < earliestDate) {
+      return helpers.error('date.min', { ...context, limit: earliestDate })
+    }
+
+    // Maximum date from today
+    const latestDate = options.latestMonthYear
+      ? new Date(`${options.latestMonthYear}-01`)
+      : undefined
+
+    if (latestDate && date > latestDate) {
+      return helpers.error('date.max', { ...context, limit: latestDate })
     }
 
     return payload


### PR DESCRIPTION
<!--
  Thank you for contributing to DXT! Please follow the instructions in the comment tags.
  Unless you have been instructed, do not delete any text in this template.
-->

Dependent on https://github.com/DEFRA/forms-designer/pull/1484

## Proposed change

Add validation to the MonthYearField to support absolute date range options

<!--
  Give a high-level description of the content of this pull request. No more than a couple of sentences.

  If you have consulted with the Defra Forms team prior to implementation, they will have provided you with an Azure DevOps work item number or (preferably) a link. Please include this.
-->

Jira ticket: https://eaflood.atlassian.net/browse/DF-951

## Type of change

<!--
  What type of change is this pull request? Mark the option with an X inside the brackets.
  If your change covers multiple categories, please split the pull request up to make it easier to review.
-->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc. (documentation, build updates, etc)

## Checklist

<!--
  Mark each completed item with an X, e.g. "[X] You have....".
  Feel free to chat to us on Slack if you have any questions.

  If you have not completed all of this, you are welcome to submit your pull request in a draft state
  to give us visibility and gather early feedback until it is ready for review.
-->

- []  You have executed this code locally and it performs as expected.
- [x] You have added tests to verify your code works.
- [x] You have added code comments and JSDoc, where appropriate.
- [x] There is no commented-out code.
- [x] You have added developer docs in `README.md` and `docs/*` (where appropriate, e.g. new features).
- [x] The tests are passing (`npm run test`).
- [x] The linting checks are passing (`npm run lint`).
- [x] The code has been formatted (`npm run format`).
