### PR TITLE
DF-1150: Use error description as the label if it exists

### DIFF
--- a/src/server/plugins/engine/components/FormComponent.ts
+++ b/src/server/plugins/engine/components/FormComponent.ts
@@ -44,10 +44,20 @@ export class FormComponent extends ComponentBase {
 
     this.type = type
     this.hint = hint
-    this.label =
-      'shortDescription' in def && def.shortDescription
-        ? def.shortDescription
-        : def.title
+
+    this.label = this.getLabel(def)
+  }
+
+  getLabel(def: FormComponentsDef) {
+    if ('errorDescription' in def && def.errorDescription) {
+      return def.errorDescription
+    }
+
+    if ('shortDescription' in def && def.shortDescription) {
+      return def.shortDescription
+    }
+
+    return def.title
   }
 
   get keys() {

--- a/src/server/plugins/engine/components/TextField.test.ts
+++ b/src/server/plugins/engine/components/TextField.test.ts
@@ -209,7 +209,33 @@ describe('TextField', () => {
   describe('Validation', () => {
     describe.each([
       {
-        description: 'Use short description if it exists',
+        description: 'Use error description if it exists',
+        component: {
+          title: 'What is your example text?',
+          errorDescription: 'Example text',
+          shortDescription: 'Your example text',
+          name: 'myComponent',
+          type: ComponentType.TextField,
+          options: {},
+          schema: {}
+        } satisfies TextFieldComponent,
+        assertions: [
+          {
+            input: getFormData(''),
+            output: {
+              value: getFormData(''),
+              errors: [
+                expect.objectContaining({
+                  text: 'Enter example text'
+                })
+              ]
+            }
+          }
+        ]
+      },
+      {
+        description:
+          'Use short description if it exists and error description does not',
         component: {
           title: 'What is your example text?',
           shortDescription: 'Your example text',

--- a/src/server/plugins/engine/components/UkAddressField.ts
+++ b/src/server/plugins/engine/components/UkAddressField.ts
@@ -1,8 +1,4 @@
-import {
-  ComponentType,
-  type FormComponentsDef,
-  type UkAddressFieldComponent
-} from '@defra/forms-model'
+import { ComponentType, type UkAddressFieldComponent } from '@defra/forms-model'
 import { type ObjectSchema } from 'joi'
 import lowerFirst from 'lodash/lowerFirst.js'
 
@@ -34,15 +30,13 @@ export class UkAddressField extends FormComponent {
   declare stateSchema: ObjectSchema<FormState>
   declare collection: ComponentCollection
 
-  shortDescription: FormComponentsDef['shortDescription']
-
   constructor(
     def: UkAddressFieldComponent,
     props: ConstructorParameters<typeof FormComponent>[1]
   ) {
     super(def, props)
 
-    const { name, options, shortDescription } = def
+    const { name, options } = def
 
     const isRequired = options.required !== false
     const hideOptional = !!options.optionalText
@@ -126,7 +120,6 @@ export class UkAddressField extends FormComponent {
     this.options = options
     this.formSchema = this.collection.formSchema
     this.stateSchema = this.collection.stateSchema
-    this.shortDescription = shortDescription
   }
 
   getFormValueFromState(state: FormSubmissionState) {
@@ -174,14 +167,14 @@ export class UkAddressField extends FormComponent {
     // When using postcode lookup, the address fields are hidden
     // so we replace any individual validation messages with a single one
     if (this.shouldUsePostcodeLookup() && uniqueErrors?.length) {
-      const { name, shortDescription } = this
+      const { name, label } = this
 
       return [
         {
           name,
           path: [name],
           href: `#${name}`,
-          text: `Enter ${lowerFirst(shortDescription)}`
+          text: `Enter ${lowerFirst(label)}`
         }
       ]
     }

--- a/test/form/definitions/postcode-lookup.js
+++ b/test/form/definitions/postcode-lookup.js
@@ -20,6 +20,7 @@ export default /** @satisfies {FormDefinition} */ ({
           title: 'What is your address?',
           name: 'ybMHIv',
           shortDescription: 'Address',
+          errorDescription: 'Your address',
           hint: '',
           options: {
             required: true,

--- a/test/form/postcode-lookup.test.js
+++ b/test/form/postcode-lookup.test.js
@@ -101,7 +101,7 @@ describe('Postcode lookup form pages', () => {
 
     const $errorItems = within($errorSummary).getAllByRole('listitem')
     expect($errorItems).toHaveLength(1)
-    expect($errorItems[0]).toHaveTextContent('Enter address')
+    expect($errorItems[0]).toHaveTextContent('Enter your address')
   })
 
   it('should dispatch to details page on POST', async () => {


### PR DESCRIPTION
<!--
  Thank you for contributing to DXT! Please follow the instructions in the comment tags.
  Unless you have been instructed, do not delete any text in this template.
-->

## Proposed change

Includes an optional error description key (`errorDescription`) on `FormComponent`s to use in error messages over the `shortDescription` and `title`
<img width="662" height="760" alt="image" src="https://github.com/user-attachments/assets/61662097-0a7a-460c-9a1b-2fab50226da0" />

<!--
  Give a high-level description of the content of this pull request. No more than a couple of sentences.

  If you have consulted with the Defra Forms team prior to implementation, they will have provided you with an Azure DevOps work item number or (preferably) a link. Please include this.
-->

Jira ticket: https://eaflood.atlassian.net/browse/DF-1150

## Type of change

<!--
  What type of change is this pull request? Mark the option with an X inside the brackets.
  If your change covers multiple categories, please split the pull request up to make it easier to review.
-->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc. (documentation, build updates, etc)

## Checklist

<!--
  Mark each completed item with an X, e.g. "[X] You have....".
  Feel free to chat to us on Slack if you have any questions.

  If you have not completed all of this, you are welcome to submit your pull request in a draft state
  to give us visibility and gather early feedback until it is ready for review.
-->

- [x] You have executed this code locally and it performs as expected.
- [x] You have added tests to verify your code works.
- [x] You have added code comments and JSDoc, where appropriate.
- [x] There is no commented-out code.
- [x] You have added developer docs in `README.md` and `docs/*` (where appropriate, e.g. new features).
- [x] The tests are passing (`npm run test`).
- [x] The linting checks are passing (`npm run lint`).
- [x] The code has been formatted (`npm run format`).
