### PR TITLE
CYA summary labels should not consider the error description

### DIFF
--- a/src/server/plugins/engine/components/FormComponent.ts
+++ b/src/server/plugins/engine/components/FormComponent.ts
@@ -30,6 +30,7 @@ export class FormComponent extends ComponentBase {
   type: FormComponentsDef['type']
   hint: FormComponentsDef['hint']
   label: string
+  summaryLabel: string
 
   isFormComponent = true
   isAppendageStateSingleObject = false
@@ -46,6 +47,7 @@ export class FormComponent extends ComponentBase {
     this.hint = hint
 
     this.label = this.getLabel(def)
+    this.summaryLabel = this.getSummaryLabel(def)
   }
 
   getLabel(def: FormComponentsDef) {
@@ -53,6 +55,10 @@ export class FormComponent extends ComponentBase {
       return def.errorDescription
     }
 
+    return this.getSummaryLabel(def)
+  }
+
+  getSummaryLabel(def: FormComponentsDef) {
     if ('shortDescription' in def && def.shortDescription) {
       return def.shortDescription
     }

--- a/src/server/plugins/engine/models/SummaryViewModel.ts
+++ b/src/server/plugins/engine/models/SummaryViewModel.ts
@@ -228,8 +228,8 @@ export function ItemField(
     label: field.title,
     title:
       field.options.required === false
-        ? `${field.label} (optional)`
-        : field.label,
+        ? `${field.summaryLabel} (optional)`
+        : field.summaryLabel,
     error: field.getFirstError(options.errors),
     value: getAnswer(field, state),
     href: getPageHref(page, options.path, {

--- a/src/server/plugins/engine/pageControllers/SummaryPageController.ts
+++ b/src/server/plugins/engine/pageControllers/SummaryPageController.ts
@@ -570,7 +570,7 @@ function getPaymentFieldItems(
           name: field.name,
           page,
           title: field.title,
-          label: field.label,
+          label: field.summaryLabel,
           field,
           state: context.state,
           href: page.href,


### PR DESCRIPTION
<!--
  Thank you for contributing to DXT! Please follow the instructions in the comment tags.
  Unless you have been instructed, do not delete any text in this template.
-->

## Proposed change
CYA summary labels should use `shortDescription ?? title`, not `errorDescription ?? shortDescription ?? title`

<!--
  Give a high-level description of the content of this pull request. No more than a couple of sentences.

  If you have consulted with the Defra Forms team prior to implementation, they will have provided you with an Azure DevOps work item number or (preferably) a link. Please include this.
-->

Jira ticket: https://eaflood.atlassian.net/browse/DF-1150

## Type of change

<!--
  What type of change is this pull request? Mark the option with an X inside the brackets.
  If your change covers multiple categories, please split the pull request up to make it easier to review.
-->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc. (documentation, build updates, etc)

## Checklist

<!--
  Mark each completed item with an X, e.g. "[X] You have....".
  Feel free to chat to us on Slack if you have any questions.

  If you have not completed all of this, you are welcome to submit your pull request in a draft state
  to give us visibility and gather early feedback until it is ready for review.
-->

- [x] You have executed this code locally and it performs as expected.
- [x] You have added tests to verify your code works.
- [x] You have added code comments and JSDoc, where appropriate.
- [x] There is no commented-out code.
- [x] You have added developer docs in `README.md` and `docs/*` (where appropriate, e.g. new features).
- [x] The tests are passing (`npm run test`).
- [x] The linting checks are passing (`npm run lint`).
- [x] The code has been formatted (`npm run format`).
