### PR TITLE
Bug/optional geospatial component submit data

### DIFF
--- a/src/server/plugins/engine/pageControllers/helpers/submission.test.ts
+++ b/src/server/plugins/engine/pageControllers/helpers/submission.test.ts
@@ -284,6 +284,36 @@ describe('Submission helpers', () => {
         }
       ])
     })
+
+    it('should send empty string for optional GeospatialField', () => {
+      const mockGeospatialField = Object.create(
+        GeospatialField.prototype
+      ) as GeospatialField
+      mockGeospatialField.name = 'geospatial'
+      mockGeospatialField.options = { required: false }
+
+      const items = [
+        {
+          name: 'geospatial',
+          label: 'Site features',
+          field: mockGeospatialField,
+          state: {
+            geospatial: undefined
+          } as FormSubmissionState
+        }
+      ] as unknown as DetailItemField[]
+
+      const result = buildMainRecords(items)
+
+      expect(result).toHaveLength(1)
+      expect(result).toEqual([
+        {
+          name: 'geospatial',
+          title: 'Site features',
+          value: ''
+        }
+      ])
+    })
   })
 
   describe('buildRepeaterRecords', () => {
@@ -377,6 +407,52 @@ describe('Submission helpers', () => {
                 title: 'Site features',
                 value:
                   '[{"type":"Feature","properties":{"description":"My farm house","coordinateGridReference":"ST 00001","centroidGridReference":"ST 00001"},"geometry":{"coordinates":[-2.5723699109417737,53.2380485215034],"type":"Point"},"id":"a"}]'
+              }
+            ]
+          ]
+        }
+      ])
+    })
+
+    it('should send empty string for optional GeospatialField', () => {
+      const mockGeospatialField = Object.create(
+        GeospatialField.prototype
+      ) as GeospatialField
+      mockGeospatialField.name = 'geospatial'
+      mockGeospatialField.options = { required: false }
+
+      const items = [
+        {
+          name: 'features',
+          label: 'Site features repeater',
+          subItems: [
+            [
+              {
+                name: 'geospatial',
+                label: 'Site features',
+                field: mockGeospatialField,
+                state: {
+                  geospatial: undefined
+                } as FormSubmissionState
+              } as unknown as DetailItemField[]
+            ]
+          ]
+        }
+      ] as unknown as DetailItemField[]
+
+      const result = buildRepeaterRecords(items)
+
+      expect(result).toHaveLength(1)
+      expect(result).toEqual([
+        {
+          name: 'features',
+          title: 'Site features repeater',
+          value: [
+            [
+              {
+                name: 'geospatial',
+                title: 'Site features',
+                value: ''
               }
             ]
           ]

--- a/src/server/plugins/engine/pageControllers/helpers/submission.ts
+++ b/src/server/plugins/engine/pageControllers/helpers/submission.ts
@@ -110,18 +110,24 @@ export function buildRepeaterRecords(
       name: item.name,
       title: item.label,
       value: item.subItems.map((detailItems) =>
-        detailItems.map((subItem) => ({
-          name: subItem.name,
-          title: subItem.label,
-          value:
+        detailItems.map((subItem) => {
+          let value
+
+          if (subItem.field instanceof GeospatialField) {
             // Stringify of GeoJSON is done here rather than inside `getContextValueFromState`
             // so we don't incur the overhead of JSON.stringify on every request when building context
-            subItem.field instanceof GeospatialField
-              ? JSON.stringify(
-                  subItem.field.getFormValueFromState(subItem.state)
-                )
-              : getAnswer(subItem.field, subItem.state, { format: 'data' })
-        }))
+            const formValue = subItem.field.getFormValueFromState(subItem.state)
+            value = formValue === undefined ? '' : JSON.stringify(formValue)
+          } else {
+            value = getAnswer(subItem.field, subItem.state, { format: 'data' })
+          }
+
+          return {
+            name: subItem.name,
+            title: subItem.label,
+            value
+          }
+        })
       )
     }))
 }

--- a/src/server/plugins/engine/pageControllers/helpers/submission.ts
+++ b/src/server/plugins/engine/pageControllers/helpers/submission.ts
@@ -36,10 +36,11 @@ export function buildMainRecords(items: DetailItem[]): SubmitRecord[] {
     } else if (item.field instanceof GeospatialField) {
       // Stringify of GeoJSON is done here rather than inside `getContextValueFromState`
       // so we don't incur the overhead of JSON.stringify on every request when building context
+      const value = item.field.getFormValueFromState(item.state)
       records.push({
         name: item.name,
         title: item.label,
-        value: JSON.stringify(item.field.getFormValueFromState(item.state))
+        value: value === undefined ? '' : JSON.stringify(value)
       })
     } else {
       records.push({


### PR DESCRIPTION
<!--
  Thank you for contributing to DXT! Please follow the instructions in the comment tags.
  Unless you have been instructed, do not delete any text in this template.
-->

## Proposed change

While doing the ticket I noticed there was a bug that caused the submission to fail when sending optional `Geospatial` fields where the user hadn't added any features. The `submit` sent the value as `undefined` which caused a schema validation failure given it expects a string. This PR replaces `undefined` with an empty string which aligns with what `FileUpload` sends when optional.

<!--
  Give a high-level description of the content of this pull request. No more than a couple of sentences.

  If you have consulted with the Defra Forms team prior to implementation, they will have provided you with an Azure DevOps work item number or (preferably) a link. Please include this.
-->

Jira ticket: https://eaflood.atlassian.net/browse/DF-1157

## Type of change

<!--
  What type of change is this pull request? Mark the option with an X inside the brackets.
  If your change covers multiple categories, please split the pull request up to make it easier to review.
-->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc. (documentation, build updates, etc)

## Checklist

<!--
  Mark each completed item with an X, e.g. "[X] You have....".
  Feel free to chat to us on Slack if you have any questions.

  If you have not completed all of this, you are welcome to submit your pull request in a draft state
  to give us visibility and gather early feedback until it is ready for review.
-->

- [x] You have executed this code locally and it performs as expected.
- [] You have added tests to verify your code works.
- [x] You have added code comments and JSDoc, where appropriate.
- [x] There is no commented-out code.
- [x] You have added developer docs in `README.md` and `docs/*` (where appropriate, e.g. new features).
- [x] The tests are passing (`npm run test`).
- [x] The linting checks are passing (`npm run lint`).
- [x] The code has been formatted (`npm run format`).
