### PR TITLE
feat/df-1225: Translates error description if applicable

### DIFF
--- a/src/server/plugins/engine/components/ComponentBase.ts
+++ b/src/server/plugins/engine/components/ComponentBase.ts
@@ -28,6 +28,7 @@ export class ComponentBase {
 
   isFormComponent = false
   model: FormModel
+  def: ComponentDef
 
   /** joi schemas based on a component defined in the form JSON. This validates a user's answer and is generated from {@link ComponentDef} */
   formSchema: ComponentSchema = joi.string()
@@ -45,6 +46,7 @@ export class ComponentBase {
     this.type = def.type
     this.name = def.name
     this.title = def.title
+    this.def = def
 
     if ('schema' in def) {
       this.schema = def.schema

--- a/src/server/plugins/engine/components/ComponentCollection.ts
+++ b/src/server/plugins/engine/components/ComponentCollection.ts
@@ -308,11 +308,11 @@ export class ComponentCollection {
             labelOverrides[subField.name] = patchedSchema
           }
         } else {
-          const fieldAsComponentDef = field as unknown as ComponentDef
+          const componentDefWithId = { id: field.id } as unknown as ComponentDef
           const translatedLabel =
-            translator.tComponent(fieldAsComponentDef, 'errorDescription') ||
-            translator.tComponent(fieldAsComponentDef, 'shortDescription') ||
-            translator.tComponent(fieldAsComponentDef, 'title')
+            translator.tComponent(componentDefWithId, 'errorDescription') ||
+            translator.tComponent(componentDefWithId, 'shortDescription') ||
+            translator.tComponent(componentDefWithId, 'title')
           const messagesOverride =
             field.getValidationMessagesOverride(translator)
           let patchedSchema = field.formSchema

--- a/src/server/plugins/engine/components/ComponentCollection.ts
+++ b/src/server/plugins/engine/components/ComponentCollection.ts
@@ -308,12 +308,11 @@ export class ComponentCollection {
             labelOverrides[subField.name] = patchedSchema
           }
         } else {
+          const fieldAsComponentDef = field as unknown as ComponentDef
           const translatedLabel =
-            translator.tComponent(
-              field as unknown as ComponentDef,
-              'shortDescription'
-            ) ||
-            translator.tComponent(field as unknown as ComponentDef, 'title')
+            translator.tComponent(fieldAsComponentDef, 'errorDescription') ||
+            translator.tComponent(fieldAsComponentDef, 'shortDescription') ||
+            translator.tComponent(fieldAsComponentDef, 'title')
           const messagesOverride =
             field.getValidationMessagesOverride(translator)
           let patchedSchema = field.formSchema

--- a/src/server/plugins/engine/components/ComponentCollection.ts
+++ b/src/server/plugins/engine/components/ComponentCollection.ts
@@ -308,11 +308,11 @@ export class ComponentCollection {
             labelOverrides[subField.name] = patchedSchema
           }
         } else {
-          const componentDefWithId = { id: field.id } as unknown as ComponentDef
+          const fieldDef = field.def
           const translatedLabel =
-            translator.tComponent(componentDefWithId, 'errorDescription') ||
-            translator.tComponent(componentDefWithId, 'shortDescription') ||
-            translator.tComponent(componentDefWithId, 'title')
+            translator.tComponent(fieldDef, 'errorDescription') ||
+            translator.tComponent(fieldDef, 'shortDescription') ||
+            translator.tComponent(fieldDef, 'title')
           const messagesOverride =
             field.getValidationMessagesOverride(translator)
           let patchedSchema = field.formSchema

--- a/src/server/plugins/engine/components/DeclarationField.ts
+++ b/src/server/plugins/engine/components/DeclarationField.ts
@@ -2,7 +2,6 @@ import {
   ComponentType,
   hasFormComponents,
   isFormType,
-  type ComponentDef,
   type DeclarationFieldComponent,
   type Item
 } from '@defra/forms-model'
@@ -148,7 +147,7 @@ export class DeclarationField extends FormComponent {
         'components.declarationField.defaultLabel'
       )
     } = this
-    const content = tComponent(this as unknown as ComponentDef, 'content')
+    const content = tComponent(this.def, 'content')
 
     const viewModel = super.getViewModel(context)
     let { fieldset, label } = viewModel

--- a/src/server/plugins/engine/components/FormComponent.ts
+++ b/src/server/plugins/engine/components/FormComponent.ts
@@ -1,5 +1,4 @@
 import {
-  type ComponentDef,
   type FormComponentsDef,
   type FormMetadata,
   type Item
@@ -178,15 +177,14 @@ export class FormComponent extends ComponentBase {
     const isRequired = !('required' in options) || options.required !== false
     const hideOptional = 'optionalText' in options && options.optionalText
 
-    const resolvedTitle =
-      tComponent(this as unknown as ComponentDef, 'title') || title
+    const resolvedTitle = tComponent(this.def, 'title') || title
     const optionalTag =
       !isRequired && !hideOptional ? ` ${t('common.optional')}` : ''
     const label = `${resolvedTitle}${optionalTag}`
 
     if (hint) {
       viewModel.hint = {
-        text: tComponent(this as unknown as ComponentDef, 'hint') || hint
+        text: tComponent(this.def, 'hint') || hint
       }
     }
 

--- a/src/server/plugins/engine/components/Markdown.ts
+++ b/src/server/plugins/engine/components/Markdown.ts
@@ -1,4 +1,4 @@
-import { type ComponentDef, type MarkdownComponent } from '@defra/forms-model'
+import { type MarkdownComponent } from '@defra/forms-model'
 
 import { ComponentBase } from '~/src/server/plugins/engine/components/ComponentBase.js'
 import { type RenderContext } from '~/src/server/plugins/engine/components/types.js'
@@ -28,8 +28,7 @@ export class Markdown extends ComponentBase {
 
     return {
       ...viewModel,
-      content:
-        tComponent(this as unknown as ComponentDef, 'content') || content,
+      content: tComponent(this.def, 'content') || content,
       headerStartLevel: this.headerStartLevel
     }
   }

--- a/src/server/plugins/engine/components/TextField.test.ts
+++ b/src/server/plugins/engine/components/TextField.test.ts
@@ -272,7 +272,7 @@ describe('TextField', () => {
             language: 'en-GB'
           }
         })
-        expect(tComponent).toHaveBeenCalledWith(field, 'title')
+        expect(tComponent).toHaveBeenCalledWith(field.def, 'title')
         expect(viewModel.label.text).toBe('Translated title')
       })
 
@@ -295,7 +295,7 @@ describe('TextField', () => {
             language: 'en-GB'
           }
         })
-        expect(tComponent).toHaveBeenCalledWith(hintField, 'hint')
+        expect(tComponent).toHaveBeenCalledWith(hintField.def, 'hint')
         expect(viewModel.hint?.text).toBe('Translated hint')
       })
 

--- a/src/server/plugins/engine/i18n/types.ts
+++ b/src/server/plugins/engine/i18n/types.ts
@@ -22,6 +22,7 @@ export type FormDefinitionTranslations = Record<
         hint: string
         content: string
         shortDescription: string
+        errorDescription: string
         paymentDescription: string
       }>
     >


### PR DESCRIPTION
<!--
  Thank you for contributing to DXT! Please follow the instructions in the comment tags.
  Unless you have been instructed, do not delete any text in this template.
-->

## Proposed change
Error description can be used to override error messages (whereas shortDescription is always used for Check Your Answers).
Handles translation of errorDescription for errors, if necessary

**NOTE** - I may have missed other areas where error description should override. Please check this PR thoroughly

<!--
  Give a high-level description of the content of this pull request. No more than a couple of sentences.

  If you have consulted with the Defra Forms team prior to implementation, they will have provided you with an Azure DevOps work item number or (preferably) a link. Please include this.
-->

Jira ticket: [DF-1225](https://eaflood.atlassian.net/browse/DF-1225)

## Type of change

<!--
  What type of change is this pull request? Mark the option with an X inside the brackets.
  If your change covers multiple categories, please split the pull request up to make it easier to review.
-->

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Misc. (documentation, build updates, etc)

## Checklist

<!--
  Mark each completed item with an X, e.g. "[X] You have....".
  Feel free to chat to us on Slack if you have any questions.

  If you have not completed all of this, you are welcome to submit your pull request in a draft state
  to give us visibility and gather early feedback until it is ready for review.
-->

- [ ] You have executed this code locally and it performs as expected.
- [ ] You have added tests to verify your code works.
- [ ] You have added code comments and JSDoc, where appropriate.
- [ ] There is no commented-out code.
- [ ] You have added developer docs in `README.md` and `docs/*` (where appropriate, e.g. new features).
- [ ] The tests are passing (`npm run test`).
- [ ] The linting checks are passing (`npm run lint`).
- [ ] The code has been formatted (`npm run format`).


[DF-1225]: https://eaflood.atlassian.net/browse/DF-1225?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ