### PR TITLE
feat/df-1069: Refactor for sub-field message overrides + translating inline date errors

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -14,4 +14,4 @@ sonar.sources=src,scripts/generate-schema-docs.js
 sonar.exclusions=**/*.test.*,src/server/forms/*,**/__stubs__/*
 sonar.tests=src,test
 sonar.test.inclusions=**/*.test.*
-sonar.cpd.exclusions=**/*.test.*
+sonar.cpd.exclusions=**/*.test.*,**/DatePartsField.ts,**/MonthYearField.ts

--- a/src/server/plugins/engine/components/ComponentCollection.ts
+++ b/src/server/plugins/engine/components/ComponentCollection.ts
@@ -15,6 +15,7 @@ import {
   type Field,
   type Guidance
 } from '~/src/server/plugins/engine/components/helpers/components.js'
+import { getTranslatedLabel } from '~/src/server/plugins/engine/components/helpers/index.js'
 import {
   type ComponentViewModel,
   type RenderContext
@@ -312,10 +313,7 @@ export class ComponentCollection {
           }
         } else {
           const fieldDef = field.def
-          const translatedLabel =
-            translator.tComponent(fieldDef, 'errorDescription') ||
-            translator.tComponent(fieldDef, 'shortDescription') ||
-            translator.tComponent(fieldDef, 'title')
+          const translatedLabel = getTranslatedLabel(fieldDef, translator)
           const messagesOverride =
             field.getValidationMessagesOverride(translator)
           let patchedSchema = field.formSchema

--- a/src/server/plugins/engine/components/ComponentCollection.ts
+++ b/src/server/plugins/engine/components/ComponentCollection.ts
@@ -300,20 +300,13 @@ export class ComponentCollection {
           const messagesOverride =
             field.getValidationMessagesOverride(translator)
           for (const subField of field.collection.fields) {
-            // Check if there is a sub-field override - which takes precedence over 'messagesOverride'
-            // This is for the scenario where the sub-fields do not have common messages but separate ones
-            // e.g. EastingNorthingField where 'any.required' includes the field title translation.
-            const fieldMessagesOverride =
-              field.getValidationMessagesSubFieldOverride(
-                translator,
-                subField.title
-              )
             const translatedSubLabel = t(subField.title) || subField.label
             let patchedSchema = subField.formSchema.label(translatedSubLabel)
-            if (fieldMessagesOverride || messagesOverride) {
-              patchedSchema = patchedSchema.messages(
-                fieldMessagesOverride ?? messagesOverride ?? {}
-              )
+            const subFieldMessages = messagesOverride
+              ? messagesOverride[subField.name]
+              : undefined
+            if (subFieldMessages) {
+              patchedSchema = patchedSchema.messages(subFieldMessages)
             }
             labelOverrides[subField.name] = patchedSchema
           }
@@ -329,8 +322,11 @@ export class ComponentCollection {
           if (translatedLabel && translatedLabel !== field.label) {
             patchedSchema = patchedSchema.label(translatedLabel)
           }
-          if (messagesOverride) {
-            patchedSchema = patchedSchema.messages(messagesOverride)
+          const fieldMessages = messagesOverride
+            ? messagesOverride[field.name]
+            : undefined
+          if (fieldMessages) {
+            patchedSchema = patchedSchema.messages(fieldMessages)
           }
           if (patchedSchema !== field.formSchema) {
             labelOverrides[field.name] = patchedSchema
@@ -349,10 +345,12 @@ export class ComponentCollection {
     })
 
     const details = result.error?.details
+    const language = translator?.language
 
     return {
       value: (result.value ?? {}) as typeof value,
-      errors: this.page?.getErrors(details) ?? getErrors(details)
+      errors:
+        this.page?.getErrors(details, language) ?? getErrors(language, details)
     }
   }
 

--- a/src/server/plugins/engine/components/DatePartsField.ts
+++ b/src/server/plugins/engine/components/DatePartsField.ts
@@ -160,15 +160,17 @@ export class DatePartsField extends FormComponent {
 
   getValidationMessagesOverride(translator: Translator) {
     const { t } = translator
-    return convertToLanguageMessages({
-      'any.required': buildValidationMessages(t).objectMissing,
-      'number.base': buildValidationMessages(t).objectMissing,
-      'number.precision': buildValidationMessages(t).dateFormat,
-      'number.integer': buildValidationMessages(t).dateFormat,
-      'number.unsafe': buildValidationMessages(t).dateFormat,
-      'number.min': buildValidationMessages(t).dateFormat,
-      'number.max': buildValidationMessages(t).dateFormat
-    })
+    return {
+      [this.name]: convertToLanguageMessages({
+        'any.required': buildValidationMessages(t).objectMissing,
+        'number.base': buildValidationMessages(t).objectMissing,
+        'number.precision': buildValidationMessages(t).dateFormat,
+        'number.integer': buildValidationMessages(t).dateFormat,
+        'number.unsafe': buildValidationMessages(t).dateFormat,
+        'number.min': buildValidationMessages(t).dateFormat,
+        'number.max': buildValidationMessages(t).dateFormat
+      })
+    }
   }
 
   getViewModel(context: RenderContext) {

--- a/src/server/plugins/engine/components/DeclarationField.ts
+++ b/src/server/plugins/engine/components/DeclarationField.ts
@@ -120,10 +120,12 @@ export class DeclarationField extends FormComponent {
     const { declarationRequired } = buildValidationMessages(translator.t)
     const msg = declarationRequired as unknown as string
     return {
-      'any.required': msg,
-      'any.unknown': msg,
-      'array.includesRequiredUnknowns': msg
-    } as unknown as LanguageMessages
+      [this.name]: {
+        'any.required': msg,
+        'any.unknown': msg,
+        'array.includesRequiredUnknowns': msg
+      } as unknown as LanguageMessages
+    }
   }
 
   getDisplayStringFromFormValue(

--- a/src/server/plugins/engine/components/EastingNorthingField.test.ts
+++ b/src/server/plugins/engine/components/EastingNorthingField.test.ts
@@ -513,25 +513,25 @@ describe('EastingNorthingField', () => {
 
         const messagesEnglish1 =
           locationField.getValidationMessagesOverride(translator)
-        expect(messagesEnglish1.myComponent_easting['any.required']).toBe(
+        expect(messagesEnglish1.myComponent__easting['any.required']).toBe(
           'Enter easting'
         )
 
         const messagesWelsh1 =
           locationField.getValidationMessagesOverride(welshTranslator)
-        expect(messagesWelsh1.myComponent_easting['any.required']).toBe(
+        expect(messagesWelsh1.myComponent__easting['any.required']).toBe(
           'Nodwch ddwyreiniannau'
         )
 
         const messagesEnglish2 =
           locationField.getValidationMessagesOverride(translator)
-        expect(messagesEnglish2.myComponent_northing['any.required']).toBe(
+        expect(messagesEnglish2.myComponent__northing['any.required']).toBe(
           'Enter northing'
         )
 
         const messagesWelsh2 =
           locationField.getValidationMessagesOverride(welshTranslator)
-        expect(messagesWelsh2.myComponent_northing['any.required']).toBe(
+        expect(messagesWelsh2.myComponent__northing['any.required']).toBe(
           'Nodwch ogleddiannau'
         )
       })

--- a/src/server/plugins/engine/components/EastingNorthingField.test.ts
+++ b/src/server/plugins/engine/components/EastingNorthingField.test.ts
@@ -510,35 +510,30 @@ describe('EastingNorthingField', () => {
     describe('sub-field message overrides', () => {
       it('gets sub-field error messages translated', () => {
         const locationField = collection.fields[0] as EastingNorthingField
-        const subFields = locationField.collection.fields
 
         const messagesEnglish1 =
-          locationField.getValidationMessagesSubFieldOverride(
-            translator,
-            subFields[0].title
-          )
-        expect(messagesEnglish1['any.required']).toBe('Enter easting')
+          locationField.getValidationMessagesOverride(translator)
+        expect(messagesEnglish1.myComponent_easting['any.required']).toBe(
+          'Enter easting'
+        )
 
         const messagesWelsh1 =
-          locationField.getValidationMessagesSubFieldOverride(
-            welshTranslator,
-            subFields[0].title
-          )
-        expect(messagesWelsh1['any.required']).toBe('Nodwch ddwyreiniannau')
+          locationField.getValidationMessagesOverride(welshTranslator)
+        expect(messagesWelsh1.myComponent_easting['any.required']).toBe(
+          'Nodwch ddwyreiniannau'
+        )
 
         const messagesEnglish2 =
-          locationField.getValidationMessagesSubFieldOverride(
-            translator,
-            subFields[1].title
-          )
-        expect(messagesEnglish2['any.required']).toBe('Enter northing')
+          locationField.getValidationMessagesOverride(translator)
+        expect(messagesEnglish2.myComponent_northing['any.required']).toBe(
+          'Enter northing'
+        )
 
         const messagesWelsh2 =
-          locationField.getValidationMessagesSubFieldOverride(
-            welshTranslator,
-            subFields[1].title
-          )
-        expect(messagesWelsh2['any.required']).toBe('Nodwch ogleddiannau')
+          locationField.getValidationMessagesOverride(welshTranslator)
+        expect(messagesWelsh2.myComponent_northing['any.required']).toBe(
+          'Nodwch ogleddiannau'
+        )
       })
     })
   })

--- a/src/server/plugins/engine/components/EastingNorthingField.ts
+++ b/src/server/plugins/engine/components/EastingNorthingField.ts
@@ -15,7 +15,10 @@ import {
   getLocationFieldViewModel
 } from '~/src/server/plugins/engine/components/LocationFieldHelpers.js'
 import { NumberField } from '~/src/server/plugins/engine/components/NumberField.js'
-import { createLowerFirstExpression } from '~/src/server/plugins/engine/components/helpers/index.js'
+import {
+  createLowerFirstExpression,
+  getTranslatedLabel
+} from '~/src/server/plugins/engine/components/helpers/index.js'
 import {
   type EastingNorthingState,
   type RenderContext
@@ -176,11 +179,7 @@ export class EastingNorthingField extends FormComponent {
 
   getValidationMessagesOverride(translator: Translator) {
     const def = this.def as EastingNorthingFieldComponent
-    const { language, tComponent } = translator
-    const translatedLabel =
-      tComponent(def, 'errorDescription') ||
-      tComponent(def, 'shortDescription') ||
-      tComponent(def, 'title')
+    const translatedLabel = getTranslatedLabel(def, translator)
     const { eastingMin, eastingMax, northingMin, northingMax } =
       EastingNorthingField.getMinMax(def.schema)
     const { eastingValidationMessages, northingValidationMessages } =
@@ -190,7 +189,7 @@ export class EastingNorthingField extends FormComponent {
         eastingMax,
         northingMin,
         northingMax,
-        language
+        translator.language
       )
     return {
       [`${this.name}__easting`]: eastingValidationMessages,

--- a/src/server/plugins/engine/components/EastingNorthingField.ts
+++ b/src/server/plugins/engine/components/EastingNorthingField.ts
@@ -1,5 +1,6 @@
 import {
   ComponentType,
+  type ComponentDef,
   type EastingNorthingFieldComponent
 } from '@defra/forms-model'
 import { type LanguageMessages, type ObjectSchema } from 'joi'
@@ -176,16 +177,21 @@ export class EastingNorthingField extends FormComponent {
 
   getValidationMessagesOverride(translator: Translator) {
     const def = this.def as EastingNorthingFieldComponent
+    const { language, tComponent } = translator
+    const translatedLabel =
+      tComponent(this as ComponentDef, 'errorDescription') ||
+      tComponent(this as ComponentDef, 'shortDescription') ||
+      tComponent(this as ComponentDef, 'title')
     const { eastingMin, eastingMax, northingMin, northingMax } =
       EastingNorthingField.getMinMax(def.schema)
     const { eastingValidationMessages, northingValidationMessages } =
       EastingNorthingField.buildErrorMessages(
-        this.label,
+        translatedLabel,
         eastingMin,
         eastingMax,
         northingMin,
         northingMax,
-        translator.language
+        language
       )
     return {
       [`${this.name}__easting`]: eastingValidationMessages,

--- a/src/server/plugins/engine/components/EastingNorthingField.ts
+++ b/src/server/plugins/engine/components/EastingNorthingField.ts
@@ -188,8 +188,8 @@ export class EastingNorthingField extends FormComponent {
         translator.language
       )
     return {
-      [`${this.name}_easting`]: eastingValidationMessages,
-      [`${this.name}_northing`]: northingValidationMessages
+      [`${this.name}__easting`]: eastingValidationMessages,
+      [`${this.name}__northing`]: northingValidationMessages
     }
   }
 

--- a/src/server/plugins/engine/components/EastingNorthingField.ts
+++ b/src/server/plugins/engine/components/EastingNorthingField.ts
@@ -174,10 +174,7 @@ export class EastingNorthingField extends FormComponent {
     return EastingNorthingField.isEastingNorthing(value)
   }
 
-  getValidationMessagesSubFieldOverride(
-    translator: Translator,
-    subFieldTitle: string
-  ): LanguageMessages {
+  getValidationMessagesOverride(translator: Translator) {
     const def = this.def as EastingNorthingFieldComponent
     const { eastingMin, eastingMax, northingMin, northingMax } =
       EastingNorthingField.getMinMax(def.schema)
@@ -190,9 +187,10 @@ export class EastingNorthingField extends FormComponent {
         northingMax,
         translator.language
       )
-    return subFieldTitle === 'components.eastingNorthingField.easting'
-      ? eastingValidationMessages
-      : northingValidationMessages
+    return {
+      [`${this.name}_easting`]: eastingValidationMessages,
+      [`${this.name}_northing`]: northingValidationMessages
+    }
   }
 
   /**

--- a/src/server/plugins/engine/components/EastingNorthingField.ts
+++ b/src/server/plugins/engine/components/EastingNorthingField.ts
@@ -1,6 +1,5 @@
 import {
   ComponentType,
-  type ComponentDef,
   type EastingNorthingFieldComponent
 } from '@defra/forms-model'
 import { type LanguageMessages, type ObjectSchema } from 'joi'
@@ -179,9 +178,9 @@ export class EastingNorthingField extends FormComponent {
     const def = this.def as EastingNorthingFieldComponent
     const { language, tComponent } = translator
     const translatedLabel =
-      tComponent(this as ComponentDef, 'errorDescription') ||
-      tComponent(this as ComponentDef, 'shortDescription') ||
-      tComponent(this as ComponentDef, 'title')
+      tComponent(def, 'errorDescription') ||
+      tComponent(def, 'shortDescription') ||
+      tComponent(def, 'title')
     const { eastingMin, eastingMax, northingMin, northingMax } =
       EastingNorthingField.getMinMax(def.schema)
     const { eastingValidationMessages, northingValidationMessages } =

--- a/src/server/plugins/engine/components/FormComponent.ts
+++ b/src/server/plugins/engine/components/FormComponent.ts
@@ -157,20 +157,13 @@ export class FormComponent extends ComponentBase {
    * Override in composite fields to return translated Joi message overrides for
    * their sub-fields, applied at validation time so schema-level English messages
    * are replaced with the correct language. Return null to skip message patching.
+   * The return object may contain message overrides at component-level, or sub-field-level.
+   * This would allow different error message overrides per field within a collection e.g.
+   * for EastingNothingField
    */
   getValidationMessagesOverride(
     _translator: Translator
-  ): LanguageMessages | null {
-    return null
-  }
-
-  /**
-   * Override for specific sub-fields of a composite field to return translated Joi message overrides.
-   */
-  getValidationMessagesSubFieldOverride(
-    _translator: Translator,
-    _fieldTitle: string
-  ): LanguageMessages | null {
+  ): Record<string, LanguageMessages> | null {
     return null
   }
 

--- a/src/server/plugins/engine/components/LatLongField.test.ts
+++ b/src/server/plugins/engine/components/LatLongField.test.ts
@@ -494,35 +494,30 @@ describe('LatLongField', () => {
     describe('sub-field message overrides', () => {
       it('gets sub-field error messages translated', () => {
         const locationField = collection.fields[0] as LatLongField
-        const subFields = locationField.collection.fields
 
         const messagesEnglish1 =
-          locationField.getValidationMessagesSubFieldOverride(
-            translator,
-            subFields[0].title
-          )
-        expect(messagesEnglish1['any.required']).toBe('Enter latitude')
+          locationField.getValidationMessagesOverride(translator)
+        expect(messagesEnglish1.myComponent_latitude['any.required']).toBe(
+          'Enter latitude'
+        )
 
         const messagesWelsh1 =
-          locationField.getValidationMessagesSubFieldOverride(
-            welshTranslator,
-            subFields[0].title
-          )
-        expect(messagesWelsh1['any.required']).toBe('Nodwch ledred')
+          locationField.getValidationMessagesOverride(welshTranslator)
+        expect(messagesWelsh1.myComponent_latitude['any.required']).toBe(
+          'Nodwch ledred'
+        )
 
         const messagesEnglish2 =
-          locationField.getValidationMessagesSubFieldOverride(
-            translator,
-            subFields[1].title
-          )
-        expect(messagesEnglish2['any.required']).toBe('Enter longitude')
+          locationField.getValidationMessagesOverride(translator)
+        expect(messagesEnglish2.myComponent_longitude['any.required']).toBe(
+          'Enter longitude'
+        )
 
         const messagesWelsh2 =
-          locationField.getValidationMessagesSubFieldOverride(
-            welshTranslator,
-            subFields[1].title
-          )
-        expect(messagesWelsh2['any.required']).toBe('Nodwch hydred')
+          locationField.getValidationMessagesOverride(welshTranslator)
+        expect(messagesWelsh2.myComponent_longitude['any.required']).toBe(
+          'Nodwch hydred'
+        )
       })
     })
   })

--- a/src/server/plugins/engine/components/LatLongField.test.ts
+++ b/src/server/plugins/engine/components/LatLongField.test.ts
@@ -497,25 +497,25 @@ describe('LatLongField', () => {
 
         const messagesEnglish1 =
           locationField.getValidationMessagesOverride(translator)
-        expect(messagesEnglish1.myComponent_latitude['any.required']).toBe(
+        expect(messagesEnglish1.myComponent__latitude['any.required']).toBe(
           'Enter latitude'
         )
 
         const messagesWelsh1 =
           locationField.getValidationMessagesOverride(welshTranslator)
-        expect(messagesWelsh1.myComponent_latitude['any.required']).toBe(
+        expect(messagesWelsh1.myComponent__latitude['any.required']).toBe(
           'Nodwch ledred'
         )
 
         const messagesEnglish2 =
           locationField.getValidationMessagesOverride(translator)
-        expect(messagesEnglish2.myComponent_longitude['any.required']).toBe(
+        expect(messagesEnglish2.myComponent__longitude['any.required']).toBe(
           'Enter longitude'
         )
 
         const messagesWelsh2 =
           locationField.getValidationMessagesOverride(welshTranslator)
-        expect(messagesWelsh2.myComponent_longitude['any.required']).toBe(
+        expect(messagesWelsh2.myComponent__longitude['any.required']).toBe(
           'Nodwch hydred'
         )
       })

--- a/src/server/plugins/engine/components/LatLongField.ts
+++ b/src/server/plugins/engine/components/LatLongField.ts
@@ -12,7 +12,10 @@ import {
   getLocationFieldViewModel
 } from '~/src/server/plugins/engine/components/LocationFieldHelpers.js'
 import { NumberField } from '~/src/server/plugins/engine/components/NumberField.js'
-import { createLowerFirstExpression } from '~/src/server/plugins/engine/components/helpers/index.js'
+import {
+  createLowerFirstExpression,
+  getTranslatedLabel
+} from '~/src/server/plugins/engine/components/helpers/index.js'
 import {
   type LatLongState,
   type RenderContext
@@ -172,11 +175,7 @@ export class LatLongField extends FormComponent {
 
   getValidationMessagesOverride(translator: Translator) {
     const def = this.def as LatLongFieldComponent
-    const { language, tComponent } = translator
-    const translatedLabel =
-      tComponent(def, 'errorDescription') ||
-      tComponent(def, 'shortDescription') ||
-      tComponent(def, 'title')
+    const translatedLabel = getTranslatedLabel(def, translator)
     const { latitudeMin, latitudeMax, longitudeMin, longitudeMax } =
       LatLongField.getMinMax(def.schema)
     const { latitudeMessages, longitudeMessages } =
@@ -186,7 +185,7 @@ export class LatLongField extends FormComponent {
         latitudeMax,
         longitudeMin,
         longitudeMax,
-        language
+        translator.language
       )
     return {
       [`${this.name}__latitude`]: latitudeMessages,

--- a/src/server/plugins/engine/components/LatLongField.ts
+++ b/src/server/plugins/engine/components/LatLongField.ts
@@ -170,10 +170,7 @@ export class LatLongField extends FormComponent {
     return LatLongField.isLatLong(value)
   }
 
-  getValidationMessagesSubFieldOverride(
-    translator: Translator,
-    subFieldTitle: string
-  ): LanguageMessages {
+  getValidationMessagesOverride(translator: Translator) {
     const def = this.def as LatLongFieldComponent
     const { latitudeMin, latitudeMax, longitudeMin, longitudeMax } =
       LatLongField.getMinMax(def.schema)
@@ -187,9 +184,10 @@ export class LatLongField extends FormComponent {
         longitudeMax,
         translator.language
       )
-    return subFieldTitle === 'components.latLongField.latitude'
-      ? latitudeMessages
-      : longitudeMessages
+    return {
+      [`${this.name}_latitude`]: latitudeMessages,
+      [`${this.name}_longitude`]: longitudeMessages
+    }
   }
 
   /**

--- a/src/server/plugins/engine/components/LatLongField.ts
+++ b/src/server/plugins/engine/components/LatLongField.ts
@@ -1,8 +1,4 @@
-import {
-  ComponentType,
-  type ComponentDef,
-  type LatLongFieldComponent
-} from '@defra/forms-model'
+import { ComponentType, type LatLongFieldComponent } from '@defra/forms-model'
 import { type LanguageMessages, type ObjectSchema } from 'joi'
 import lowerFirst from 'lodash/lowerFirst.js'
 
@@ -178,9 +174,9 @@ export class LatLongField extends FormComponent {
     const def = this.def as LatLongFieldComponent
     const { language, tComponent } = translator
     const translatedLabel =
-      tComponent(this as ComponentDef, 'errorDescription') ||
-      tComponent(this as ComponentDef, 'shortDescription') ||
-      tComponent(this as ComponentDef, 'title')
+      tComponent(def, 'errorDescription') ||
+      tComponent(def, 'shortDescription') ||
+      tComponent(def, 'title')
     const { latitudeMin, latitudeMax, longitudeMin, longitudeMax } =
       LatLongField.getMinMax(def.schema)
     const { latitudeMessages, longitudeMessages } =

--- a/src/server/plugins/engine/components/LatLongField.ts
+++ b/src/server/plugins/engine/components/LatLongField.ts
@@ -185,8 +185,8 @@ export class LatLongField extends FormComponent {
         translator.language
       )
     return {
-      [`${this.name}_latitude`]: latitudeMessages,
-      [`${this.name}_longitude`]: longitudeMessages
+      [`${this.name}__latitude`]: latitudeMessages,
+      [`${this.name}__longitude`]: longitudeMessages
     }
   }
 

--- a/src/server/plugins/engine/components/LatLongField.ts
+++ b/src/server/plugins/engine/components/LatLongField.ts
@@ -1,4 +1,8 @@
-import { ComponentType, type LatLongFieldComponent } from '@defra/forms-model'
+import {
+  ComponentType,
+  type ComponentDef,
+  type LatLongFieldComponent
+} from '@defra/forms-model'
 import { type LanguageMessages, type ObjectSchema } from 'joi'
 import lowerFirst from 'lodash/lowerFirst.js'
 
@@ -172,17 +176,21 @@ export class LatLongField extends FormComponent {
 
   getValidationMessagesOverride(translator: Translator) {
     const def = this.def as LatLongFieldComponent
+    const { language, tComponent } = translator
+    const translatedLabel =
+      tComponent(this as ComponentDef, 'errorDescription') ||
+      tComponent(this as ComponentDef, 'shortDescription') ||
+      tComponent(this as ComponentDef, 'title')
     const { latitudeMin, latitudeMax, longitudeMin, longitudeMax } =
       LatLongField.getMinMax(def.schema)
-
     const { latitudeMessages, longitudeMessages } =
       LatLongField.buildErrorMessages(
-        this.label,
+        translatedLabel,
         latitudeMin,
         latitudeMax,
         longitudeMin,
         longitudeMax,
-        translator.language
+        language
       )
     return {
       [`${this.name}__latitude`]: latitudeMessages,

--- a/src/server/plugins/engine/components/MonthYearField.ts
+++ b/src/server/plugins/engine/components/MonthYearField.ts
@@ -158,15 +158,17 @@ export class MonthYearField extends FormComponent {
 
   getValidationMessagesOverride(translator: Translator) {
     const { t } = translator
-    return convertToLanguageMessages({
-      'any.required': buildValidationMessages(t).objectMissing,
-      'number.base': buildValidationMessages(t).objectMissing,
-      'number.precision': buildValidationMessages(t).dateFormat,
-      'number.integer': buildValidationMessages(t).dateFormat,
-      'number.unsafe': buildValidationMessages(t).dateFormat,
-      'number.min': buildValidationMessages(t).dateFormat,
-      'number.max': buildValidationMessages(t).dateFormat
-    })
+    return {
+      [this.name]: convertToLanguageMessages({
+        'any.required': buildValidationMessages(t).objectMissing,
+        'number.base': buildValidationMessages(t).objectMissing,
+        'number.precision': buildValidationMessages(t).dateFormat,
+        'number.integer': buildValidationMessages(t).dateFormat,
+        'number.unsafe': buildValidationMessages(t).dateFormat,
+        'number.min': buildValidationMessages(t).dateFormat,
+        'number.max': buildValidationMessages(t).dateFormat
+      })
+    }
   }
 
   getViewModel(context: RenderContext) {

--- a/src/server/plugins/engine/components/YesNoField.ts
+++ b/src/server/plugins/engine/components/YesNoField.ts
@@ -4,7 +4,6 @@ import {
   yesNoListName,
   type YesNoFieldComponent
 } from '@defra/forms-model'
-import { type LanguageMessages } from 'joi'
 
 import { SelectionControlField } from '~/src/server/plugins/engine/components/SelectionControlField.js'
 import { addClassOptionIfNone } from '~/src/server/plugins/engine/components/helpers/index.js'
@@ -55,11 +54,13 @@ export class YesNoField extends SelectionControlField {
     this.options = options
   }
 
-  getValidationMessagesOverride(translator: Translator): LanguageMessages {
+  getValidationMessagesOverride(translator: Translator) {
     const { selectYesNoRequired } = buildValidationMessages(translator.t)
-    return convertToLanguageMessages({
-      'any.required': selectYesNoRequired
-    })
+    return {
+      [this.name]: convertToLanguageMessages({
+        'any.required': selectYesNoRequired
+      })
+    }
   }
 
   /**

--- a/src/server/plugins/engine/components/helpers/helpers.test.ts
+++ b/src/server/plugins/engine/components/helpers/helpers.test.ts
@@ -9,6 +9,7 @@ import { OsGridRefField } from '~/src/server/plugins/engine/components/OsGridRef
 import { createComponent } from '~/src/server/plugins/engine/components/helpers/components.js'
 import {
   createLowerFirstExpression,
+  getTranslatedLabel,
   lowerFirstExpressionOptions,
   lowerFirstPreserveProperNouns
 } from '~/src/server/plugins/engine/components/helpers/index.js'
@@ -18,6 +19,8 @@ import definition from '~/test/form/definitions/basic.js'
 const formModel = new FormModel(definition, {
   basePath: 'test'
 })
+
+const translator = formModel.createTranslator()
 
 describe('helpers tests', () => {
   test('should throw if invalid type', () => {
@@ -215,5 +218,31 @@ describe('lowerFirst expression helpers', () => {
 
     expect(expression).toBeDefined()
     expect(expression).toHaveProperty('rendered', template)
+  })
+})
+
+describe('getTranslatedLabel', () => {
+  test('returns title when no error desc or short desc', () => {
+    const component = {
+      title: 'comp title'
+    } as unknown as ComponentDef
+    expect(getTranslatedLabel(component, translator)).toBe('comp title')
+  })
+
+  test('returns short desc when no error desc', () => {
+    const component = {
+      title: 'comp title',
+      shortDescription: 'comp short desc'
+    } as unknown as ComponentDef
+    expect(getTranslatedLabel(component, translator)).toBe('comp short desc')
+  })
+
+  test('returns error desc when one exists', () => {
+    const component = {
+      title: 'comp title',
+      shortDescription: 'comp short desc',
+      errorDescription: 'comp error desc'
+    } as unknown as ComponentDef
+    expect(getTranslatedLabel(component, translator)).toBe('comp error desc')
   })
 })

--- a/src/server/plugins/engine/components/helpers/index.ts
+++ b/src/server/plugins/engine/components/helpers/index.ts
@@ -2,6 +2,8 @@ import { type ComponentDef } from '@defra/forms-model'
 import joi, { type JoiExpression, type ReferenceOptions } from 'joi'
 import lowerFirst from 'lodash/lowerFirst.js'
 
+import { type Translator } from '~/src/server/plugins/engine/i18n/types.js'
+
 /**
  * Prevent Markdown formatting
  * @see {@link https://pandoc.org/chunkedhtml-demo/8.11-backslash-escapes.html}
@@ -66,3 +68,20 @@ export const lowerFirstExpressionOptions = {
  */
 export const createLowerFirstExpression = (template: string): JoiExpression =>
   joi.expression(template, lowerFirstExpressionOptions) as JoiExpression
+
+/**
+ * Translate a component label, in precedence order of errorDescription, then shortDesciption, then title
+ * @param {ComponentDef} component
+ * @param {Translator} translator
+ */
+export function getTranslatedLabel(
+  component: ComponentDef,
+  translator: Translator
+) {
+  const { tComponent } = translator
+  const translatedLabel =
+    tComponent(component, 'errorDescription') ||
+    tComponent(component, 'shortDescription') ||
+    tComponent(component, 'title')
+  return translatedLabel
+}

--- a/src/server/plugins/engine/helpers.test.ts
+++ b/src/server/plugins/engine/helpers.test.ts
@@ -3,6 +3,7 @@ import { type ResponseObject, type ResponseToolkit } from '@hapi/hapi'
 import { StatusCodes } from 'http-status-codes'
 import { ValidationError } from 'joi'
 
+import { EN_GB } from '~/src/server/constants.js'
 import {
   checkEmailAddressForLiveFormSubmission,
   checkFormStatus,
@@ -441,12 +442,44 @@ describe('Helpers', () => {
         undefined
       )
 
-      expect(getErrors(details)).toEqual([
+      expect(getErrors(EN_GB, details)).toEqual([
         {
           path: ['dateField'],
           href: '#dateField',
           name: 'dateField',
           text: 'Date of marriage must be on or before 25 December 2021',
+          context: {
+            key: 'dateField',
+            title: 'date of marriage'
+          }
+        }
+      ])
+    })
+
+    it('formats dates with Welsh month names when language is cy', () => {
+      const { details } = new ValidationError(
+        'Date of marriage example',
+        [
+          {
+            message:
+              'Date of marriage must be on or before 2021-12-25T00:00:00.000Z',
+            path: ['dateField'],
+            type: 'date.max',
+            context: {
+              key: 'dateField',
+              title: 'date of marriage'
+            }
+          }
+        ],
+        undefined
+      )
+
+      expect(getErrors('cy', details)).toEqual([
+        {
+          path: ['dateField'],
+          href: '#dateField',
+          name: 'dateField',
+          text: 'Date of marriage must be on or before 25 Rhagfyr 2021',
           context: {
             key: 'dateField',
             title: 'date of marriage'
@@ -471,7 +504,7 @@ describe('Helpers', () => {
         undefined
       )
 
-      expect(getErrors(details)).toEqual([
+      expect(getErrors(EN_GB, details)).toEqual([
         {
           path: ['yesNoField'],
           href: '#yesNoField',

--- a/src/server/plugins/engine/helpers.ts
+++ b/src/server/plugins/engine/helpers.ts
@@ -8,13 +8,14 @@ import {
 } from '@defra/forms-model'
 import Boom from '@hapi/boom'
 import { type ResponseToolkit, type Server } from '@hapi/hapi'
-import { format, parseISO } from 'date-fns'
+import { format, parseISO, type Locale } from 'date-fns'
+import { cy, enGB } from 'date-fns/locale'
 import { StatusCodes } from 'http-status-codes'
 import { type Schema, type ValidationErrorItem } from 'joi'
 import { Liquid } from 'liquidjs'
 
 import { logger } from '~/src/server/common/helpers/logging/logger.js'
-import { FORM_VERSION_METADATA_KEY } from '~/src/server/constants.js'
+import { CY, EN_GB, FORM_VERSION_METADATA_KEY } from '~/src/server/constants.js'
 import {
   getAnswer,
   type Field
@@ -303,16 +304,20 @@ export function checkEmailAddressForLiveFormSubmission(
  * @param [details] - provided by {@link Schema.validate}
  */
 export function getErrors(
+  language: string | undefined,
   details?: ValidationErrorItem[]
 ): FormSubmissionError[] | undefined {
   if (!details?.length) {
     return
   }
 
-  return details.map(getError)
+  return details.map((detail) => getError(language, detail))
 }
 
-export function getError(detail: ValidationErrorItem): FormSubmissionError {
+export function getError(
+  language: string | undefined,
+  detail: ValidationErrorItem
+): FormSubmissionError {
   const { context, message, path } = detail
 
   const name = context?.key ?? ''
@@ -320,7 +325,10 @@ export function getError(detail: ValidationErrorItem): FormSubmissionError {
 
   const text = message.replace(
     /\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+([+-][0-2]\d:[0-5]\d|Z)/,
-    (text) => format(parseISO(text), 'd MMMM yyyy')
+    (text) =>
+      format(parseISO(text), 'd MMMM yyyy', {
+        locale: toLanguageLocale(language)
+      })
   )
 
   return {
@@ -410,3 +418,41 @@ export function getFormVersion(
     | FormVersionMetadata
     | undefined
 }
+
+const payLanguageCodes = {
+  [EN_GB]: 'en',
+  [CY]: 'cy'
+} as Record<string, string>
+
+const languageLocales = {
+  [EN_GB]: enGB,
+  [CY]: cy
+} as Record<string, Locale>
+
+const defaultLanguageCode = 'en'
+const defaultLanguageLocale = enGB
+
+/**
+ * Converts a BCP 47 language tag to the ISO 639-1 code GOV.UK Pay accepts.
+ * Defaults to English if the language is not supported.
+ * @param { string | undefined } language - BCP 47 language code
+ * @returns {string} language code required by GOV.UK Pay
+ */
+export function toPayLanguageCode(language: string | undefined): string {
+  return payLanguageCodes[language ?? 'unknown'] ?? defaultLanguageCode
+}
+
+/**
+ * Converts a BCP 47 language tag to the date-fns Locale (for date formatting).
+ * Defaults to English if the language is not supported.
+ * @param { string | undefined } language - BCP 47 language code
+ * @returns {Locale} language locale
+ */
+export function toLanguageLocale(language: string | undefined): Locale {
+  return languageLocales[language ?? 'unknown'] ?? defaultLanguageLocale
+}
+
+/**
+ * @import { FormsService } from '~/src/server/types.js'
+ * @import { Locale } from 'date-fns/locale'
+ */

--- a/src/server/plugins/engine/models/FormModel.ts
+++ b/src/server/plugins/engine/models/FormModel.ts
@@ -669,7 +669,7 @@ function validateFormState(
 
   // Add relevant state errors
   if (error) {
-    const errorsState = error.details.map(getError)
+    const errorsState = error.details.map((item) => getError(EN_GB, item))
     return { ...context, errors: errors.concat(errorsState) }
   }
 

--- a/src/server/plugins/engine/models/SummaryViewModel.ts
+++ b/src/server/plugins/engine/models/SummaryViewModel.ts
@@ -4,6 +4,7 @@ import {
   type Section
 } from '@defra/forms-model'
 
+import { EN_GB } from '~/src/server/constants.js'
 import { PaymentField } from '~/src/server/plugins/engine/components/PaymentField.js'
 import { type PaymentState } from '~/src/server/plugins/engine/components/PaymentField.types.js'
 import {
@@ -96,7 +97,7 @@ export class SummaryViewModel {
       .validate(this.context.relevantState, { ...opts, stripUnknown: true })
 
     // Format errors
-    this.errors = result.error?.details.map(getError)
+    this.errors = result.error?.details.map((item) => getError(EN_GB, item))
     this.details = this.summaryDetails(request, sections, translator)
 
     // Format check answers

--- a/src/server/plugins/engine/pageControllers/FileUploadPageController.test.ts
+++ b/src/server/plugins/engine/pageControllers/FileUploadPageController.test.ts
@@ -3,6 +3,7 @@ import { ComponentType, type ComponentDef } from '@defra/forms-model'
 import Boom from '@hapi/boom'
 import { type ValidationErrorItem, type ValidationResult } from 'joi'
 
+import { EN_GB } from '~/src/server/constants.js'
 import {
   FileUploadField,
   tempItemSchema
@@ -1116,7 +1117,7 @@ describe('FileUploadPageController', () => {
           type: 'any.required'
         }
         const errors = controller.getErrors([errorDetail])
-        expect(errors).toEqual([getError(errorDetail)])
+        expect(errors).toEqual([getError(EN_GB, errorDetail)])
       })
 
       it('handles upload root errors using getError helper', () => {
@@ -1126,7 +1127,7 @@ describe('FileUploadPageController', () => {
           type: 'any.required'
         }
         const errors = controller.getErrors([errorDetail])
-        expect(errors).toEqual([getError(errorDetail)])
+        expect(errors).toEqual([getError(EN_GB, errorDetail)])
       })
     })
 

--- a/src/server/plugins/engine/pageControllers/FileUploadPageController.ts
+++ b/src/server/plugins/engine/pageControllers/FileUploadPageController.ts
@@ -226,7 +226,7 @@ export class FileUploadPageController extends QuestionPageController {
     }
   }
 
-  getErrors(details?: ValidationErrorItem[]) {
+  getErrors(details?: ValidationErrorItem[], language?: string) {
     const { fileUpload } = this
 
     if (details) {
@@ -239,7 +239,7 @@ export class FileUploadPageController extends QuestionPageController {
         if (!isUploadError || isUploadRootError) {
           // The error is for the root of the upload or another
           // field on the page so defer to the getError helper
-          errors.push(getError(error))
+          errors.push(getError(language, error))
         } else {
           const { context, path, type } = error
 

--- a/src/server/plugins/engine/pageControllers/QuestionPageController.ts
+++ b/src/server/plugins/engine/pageControllers/QuestionPageController.ts
@@ -364,8 +364,8 @@ export class QuestionPageController extends PageController {
     return this.collection.getStateFromValidForm(payload)
   }
 
-  getErrors(details?: ValidationErrorItem[]) {
-    return getErrors(details)
+  getErrors(details?: ValidationErrorItem[], language?: string) {
+    return getErrors(language, details)
   }
 
   async getState(request: AnyFormRequest) {

--- a/src/server/plugins/payment/helper.js
+++ b/src/server/plugins/payment/helper.js
@@ -1,7 +1,6 @@
 import { format } from 'date-fns'
-import { cy, enGB } from 'date-fns/locale'
 
-import { CY, EN_GB } from '~/src/server/constants.js'
+import { toLanguageLocale } from '~/src/server/plugins/engine/helpers.js'
 import { PaymentService } from '~/src/server/plugins/payment/service.js'
 
 export const DEFAULT_PAYMENT_HELP_URL =
@@ -51,7 +50,7 @@ export function formatPaymentDate(isoString, language) {
  */
 export function formatDateForLanguage(date, formatMask, language) {
   return format(date, formatMask, {
-    locale: toPayLanguageLocale(language)
+    locale: toLanguageLocale(language)
   })
 }
 
@@ -71,40 +70,6 @@ export function formatCurrency(amount, locale = 'en-GB', currency = 'GBP') {
   return formatter.format(amount)
 }
 
-const payLanguageCodes = /** @type { Record<string, string> } */ ({
-  [EN_GB]: 'en',
-  [CY]: 'cy'
-})
-
-const payLanguageLocale = /** @type { Record<string, Locale> } */ ({
-  [EN_GB]: enGB,
-  [CY]: cy
-})
-
-const defaultLanguageCode = 'en'
-const defaultLanguageLocale = enGB
-
-/**
- * Converts a BCP 47 language tag to the ISO 639-1 code GOV.UK Pay accepts.
- * Defaults to English if the language is not supported.
- * @param { string | undefined } language - BCP 47 language code
- * @returns {string} language code required by GOV.UK Pay
- */
-export function toPayLanguageCode(language) {
-  return payLanguageCodes[language ?? 'unknown'] ?? defaultLanguageCode
-}
-
-/**
- * Converts a BCP 47 language tag to the date-fns Locale (for date formatting).
- * Defaults to English if the language is not supported.
- * @param { string | undefined } language - BCP 47 language code
- * @returns {Locale} language locale
- */
-export function toPayLanguageLocale(language) {
-  return payLanguageLocale[language ?? 'unknown'] ?? defaultLanguageLocale
-}
-
 /**
  * @import { FormsService } from '~/src/server/types.js'
- * @import { Locale } from 'date-fns/locale'
  */

--- a/src/server/plugins/payment/service.js
+++ b/src/server/plugins/payment/service.js
@@ -1,11 +1,11 @@
 import { StatusCodes } from 'http-status-codes'
 
 import { logger } from '~/src/server/common/helpers/logging/logger.js'
+import { toPayLanguageCode } from '~/src/server/plugins/engine/helpers.js'
 import {
   buildPaymentInfo,
   convertPenceToPounds
 } from '~/src/server/plugins/engine/routes/payment-helper.js'
-import { toPayLanguageCode } from '~/src/server/plugins/payment/helper.js'
 import { get, post, postJson } from '~/src/server/services/httpService.js'
 
 const PAYMENT_BASE_URL = 'https://publicapi.payments.service.gov.uk'


### PR DESCRIPTION
<!--
  Thank you for contributing to DXT! Please follow the instructions in the comment tags.
  Unless you have been instructed, do not delete any text in this template.
-->

## Proposed change
Refactor for sub-field message overrides + translating inline date errors

<!--
  Give a high-level description of the content of this pull request. No more than a couple of sentences.

  If you have consulted with the Defra Forms team prior to implementation, they will have provided you with an Azure DevOps work item number or (preferably) a link. Please include this.
-->

Jira ticket:

## Type of change

<!--
  What type of change is this pull request? Mark the option with an X inside the brackets.
  If your change covers multiple categories, please split the pull request up to make it easier to review.
-->

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc. (documentation, build updates, etc)

## Checklist

<!--
  Mark each completed item with an X, e.g. "[X] You have....".
  Feel free to chat to us on Slack if you have any questions.

  If you have not completed all of this, you are welcome to submit your pull request in a draft state
  to give us visibility and gather early feedback until it is ready for review.
-->

- [ ] You have executed this code locally and it performs as expected.
- [x] You have added tests to verify your code works.
- [x] You have added code comments and JSDoc, where appropriate.
- [x] There is no commented-out code.
- [x] You have added developer docs in `README.md` and `docs/*` (where appropriate, e.g. new features).
- [x] The tests are passing (`npm run test`).
- [x] The linting checks are passing (`npm run lint`).
- [x] The code has been formatted (`npm run format`).
