### PR TITLE
fix/df-1069: Multiple fixes + full welsh component unit tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@defra/forms-model": "^3.0.692",
+        "@defra/forms-model": "^3.0.693",
         "@defra/hapi-tracing": "^1.29.0",
         "@defra/interactive-map": "^0.0.33-alpha",
         "@elastic/ecs-pino-format": "^1.5.0",
@@ -3696,9 +3696,9 @@
       }
     },
     "node_modules/@defra/forms-model": {
-      "version": "3.0.692",
-      "resolved": "https://registry.npmjs.org/@defra/forms-model/-/forms-model-3.0.692.tgz",
-      "integrity": "sha512-zJX1m6qynNdiQhAIHTpK4EOx0gsmWQbnwtbN/fhy3y5vkMc39X2jLcVFbujobge7Ad+8exAVItb4K4xN2ao0SQ==",
+      "version": "3.0.693",
+      "resolved": "https://registry.npmjs.org/@defra/forms-model/-/forms-model-3.0.693.tgz",
+      "integrity": "sha512-qD+w+vq47rzH3TdIRgxwckL4b6a5el098Dvrk7G8MN7fTLsnZZgbc5kLqed2ugIugPICBXUWopdfpjjjxUfGAA==",
       "license": "OGL-UK-3.0",
       "dependencies": {
         "@joi/date": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
   },
   "license": "SEE LICENSE IN LICENSE",
   "dependencies": {
-    "@defra/forms-model": "^3.0.692",
+    "@defra/forms-model": "^3.0.693",
     "@defra/hapi-tracing": "^1.29.0",
     "@defra/interactive-map": "^0.0.33-alpha",
     "@elastic/ecs-pino-format": "^1.5.0",

--- a/src/server/plugins/engine/components/AutocompleteField.ts
+++ b/src/server/plugins/engine/components/AutocompleteField.ts
@@ -1,11 +1,11 @@
 import { type AutocompleteFieldComponent } from '@defra/forms-model'
+import { type LanguageMessages } from 'joi'
 
 import { SelectField } from '~/src/server/plugins/engine/components/SelectField.js'
 import { type RenderContext } from '~/src/server/plugins/engine/components/types.js'
 import { buildValidationMessages } from '~/src/server/plugins/engine/i18n/buildValidationMessages.js'
 import { messageTemplate } from '~/src/server/plugins/engine/pageControllers/validationOptions.js'
 import { type Translator } from '~/src/server/plugins/engine/types/index.js'
-import { convertToLanguageMessages } from '~/src/server/utils/type-utils.js'
 
 export class AutocompleteField extends SelectField {
   declare options: AutocompleteFieldComponent['options']
@@ -52,10 +52,10 @@ export class AutocompleteField extends SelectField {
   getValidationMessagesOverride(translator: Translator) {
     const { t } = translator
     return {
-      [this.name]: convertToLanguageMessages({
+      [this.name]: {
         'any.required': buildValidationMessages(t).objectRequired,
         'any.only': buildValidationMessages(t).objectRequired
-      })
+      } as LanguageMessages
     }
   }
 }

--- a/src/server/plugins/engine/components/AutocompleteField.ts
+++ b/src/server/plugins/engine/components/AutocompleteField.ts
@@ -2,7 +2,10 @@ import { type AutocompleteFieldComponent } from '@defra/forms-model'
 
 import { SelectField } from '~/src/server/plugins/engine/components/SelectField.js'
 import { type RenderContext } from '~/src/server/plugins/engine/components/types.js'
+import { buildValidationMessages } from '~/src/server/plugins/engine/i18n/buildValidationMessages.js'
 import { messageTemplate } from '~/src/server/plugins/engine/pageControllers/validationOptions.js'
+import { type Translator } from '~/src/server/plugins/engine/types/index.js'
+import { convertToLanguageMessages } from '~/src/server/utils/type-utils.js'
 
 export class AutocompleteField extends SelectField {
   declare options: AutocompleteFieldComponent['options']
@@ -43,6 +46,16 @@ export class AutocompleteField extends SelectField {
     return {
       ...viewModel,
       formGroup
+    }
+  }
+
+  getValidationMessagesOverride(translator: Translator) {
+    const { t } = translator
+    return {
+      [this.name]: convertToLanguageMessages({
+        'any.required': buildValidationMessages(t).objectRequired,
+        'any.only': buildValidationMessages(t).objectRequired
+      })
     }
   }
 }

--- a/src/server/plugins/engine/components/CheckboxesField.ts
+++ b/src/server/plugins/engine/components/CheckboxesField.ts
@@ -1,5 +1,5 @@
 import { type CheckboxesFieldComponent, type Item } from '@defra/forms-model'
-import joi, { type ArraySchema } from 'joi'
+import joi, { type ArraySchema, type LanguageMessages } from 'joi'
 
 import { isFormValue } from '~/src/server/plugins/engine/components/FormComponent.js'
 import { SelectionControlField } from '~/src/server/plugins/engine/components/SelectionControlField.js'
@@ -14,7 +14,6 @@ import {
   type FormStateValue,
   type FormSubmissionState
 } from '~/src/server/plugins/engine/types.js'
-import { convertToLanguageMessages } from '~/src/server/utils/type-utils.js'
 
 export class CheckboxesField extends SelectionControlField {
   declare options: CheckboxesFieldComponent['options']
@@ -138,11 +137,11 @@ export class CheckboxesField extends SelectionControlField {
   getValidationMessagesOverride(translator: Translator) {
     const { t } = translator
     return {
-      [this.name]: convertToLanguageMessages({
+      [this.name]: {
         'array.min': buildValidationMessages(t).arrayMin,
         'array.max': buildValidationMessages(t).arrayMax,
         'array.length': buildValidationMessages(t).arrayLength
-      })
+      } as LanguageMessages
     }
   }
 

--- a/src/server/plugins/engine/components/CheckboxesField.ts
+++ b/src/server/plugins/engine/components/CheckboxesField.ts
@@ -3,6 +3,7 @@ import joi, { type ArraySchema } from 'joi'
 
 import { isFormValue } from '~/src/server/plugins/engine/components/FormComponent.js'
 import { SelectionControlField } from '~/src/server/plugins/engine/components/SelectionControlField.js'
+import { buildValidationMessages } from '~/src/server/plugins/engine/i18n/buildValidationMessages.js'
 import { type Translator } from '~/src/server/plugins/engine/i18n/types.js'
 import { type FormModel } from '~/src/server/plugins/engine/models/FormModel.js'
 import { type QuestionPageController } from '~/src/server/plugins/engine/pageControllers/QuestionPageController.js'
@@ -13,6 +14,7 @@ import {
   type FormStateValue,
   type FormSubmissionState
 } from '~/src/server/plugins/engine/types.js'
+import { convertToLanguageMessages } from '~/src/server/utils/type-utils.js'
 
 export class CheckboxesField extends SelectionControlField {
   declare options: CheckboxesFieldComponent['options']
@@ -131,6 +133,17 @@ export class CheckboxesField extends SelectionControlField {
     const values = this.getFormValueFromState(state)
 
     return this.getContextValueFromFormValue(values)
+  }
+
+  getValidationMessagesOverride(translator: Translator) {
+    const { t } = translator
+    return {
+      [this.name]: convertToLanguageMessages({
+        'array.min': buildValidationMessages(t).arrayMin,
+        'array.max': buildValidationMessages(t).arrayMax,
+        'array.length': buildValidationMessages(t).arrayLength
+      })
+    }
   }
 
   /**

--- a/src/server/plugins/engine/components/DatePartsField.ts
+++ b/src/server/plugins/engine/components/DatePartsField.ts
@@ -160,16 +160,19 @@ export class DatePartsField extends FormComponent {
 
   getValidationMessagesOverride(translator: Translator) {
     const { t } = translator
+    const messages = convertToLanguageMessages({
+      'any.required': buildValidationMessages(t).objectMissing,
+      'number.base': buildValidationMessages(t).objectMissing,
+      'number.precision': buildValidationMessages(t).dateFormat,
+      'number.integer': buildValidationMessages(t).dateFormat,
+      'number.unsafe': buildValidationMessages(t).dateFormat,
+      'number.min': buildValidationMessages(t).dateFormat,
+      'number.max': buildValidationMessages(t).dateFormat
+    })
     return {
-      [this.name]: convertToLanguageMessages({
-        'any.required': buildValidationMessages(t).objectMissing,
-        'number.base': buildValidationMessages(t).objectMissing,
-        'number.precision': buildValidationMessages(t).dateFormat,
-        'number.integer': buildValidationMessages(t).dateFormat,
-        'number.unsafe': buildValidationMessages(t).dateFormat,
-        'number.min': buildValidationMessages(t).dateFormat,
-        'number.max': buildValidationMessages(t).dateFormat
-      })
+      [`${this.name}__day`]: messages,
+      [`${this.name}__month`]: messages,
+      [`${this.name}__year`]: messages
     }
   }
 

--- a/src/server/plugins/engine/components/DatePartsField.ts
+++ b/src/server/plugins/engine/components/DatePartsField.ts
@@ -1,6 +1,11 @@
 import { ComponentType, type DatePartsFieldComponent } from '@defra/forms-model'
 import { add, format, isValid, parse, startOfToday, sub } from 'date-fns'
-import { type Context, type CustomValidator, type ObjectSchema } from 'joi'
+import {
+  type Context,
+  type CustomValidator,
+  type LanguageMessages,
+  type ObjectSchema
+} from 'joi'
 
 import { ComponentCollection } from '~/src/server/plugins/engine/components/ComponentCollection.js'
 import {
@@ -26,7 +31,6 @@ import {
   type FormSubmissionState
 } from '~/src/server/plugins/engine/types.js'
 import { formatDateForLanguage } from '~/src/server/plugins/payment/helper.js'
-import { convertToLanguageMessages } from '~/src/server/utils/type-utils.js'
 
 export class DatePartsField extends FormComponent {
   declare options: DatePartsFieldComponent['options']
@@ -44,7 +48,7 @@ export class DatePartsField extends FormComponent {
 
     const isRequired = options.required !== false
 
-    const customValidationMessages = convertToLanguageMessages({
+    const customValidationMessages = {
       'any.required': messageTemplate.objectMissing,
       'number.base': messageTemplate.objectMissing,
       'number.precision': messageTemplate.dateFormat,
@@ -52,7 +56,7 @@ export class DatePartsField extends FormComponent {
       'number.unsafe': messageTemplate.dateFormat,
       'number.min': messageTemplate.dateFormat,
       'number.max': messageTemplate.dateFormat
-    })
+    } as LanguageMessages
 
     this.collection = new ComponentCollection(
       [
@@ -160,7 +164,7 @@ export class DatePartsField extends FormComponent {
 
   getValidationMessagesOverride(translator: Translator) {
     const { t } = translator
-    const messages = convertToLanguageMessages({
+    const messages = {
       'any.required': buildValidationMessages(t).objectMissing,
       'number.base': buildValidationMessages(t).objectMissing,
       'number.precision': buildValidationMessages(t).dateFormat,
@@ -168,7 +172,7 @@ export class DatePartsField extends FormComponent {
       'number.unsafe': buildValidationMessages(t).dateFormat,
       'number.min': buildValidationMessages(t).dateFormat,
       'number.max': buildValidationMessages(t).dateFormat
-    })
+    } as LanguageMessages
     return {
       [`${this.name}__day`]: messages,
       [`${this.name}__month`]: messages,

--- a/src/server/plugins/engine/components/EastingNorthingField.ts
+++ b/src/server/plugins/engine/components/EastingNorthingField.ts
@@ -34,7 +34,6 @@ import {
   type FormSubmissionError,
   type FormSubmissionState
 } from '~/src/server/plugins/engine/types.js'
-import { convertToLanguageMessages } from '~/src/server/utils/type-utils.js'
 
 // British National Grid coordinate limits
 const DEFAULT_EASTING_MIN = 0
@@ -284,71 +283,69 @@ export class EastingNorthingField extends FormComponent {
       { fieldLabel }
     )
 
-    const eastingValidationMessages: LanguageMessages =
-      convertToLanguageMessages({
-        'any.required': tPlugin(
-          'components.eastingNorthingField.eastingRequired',
-          language
-        ),
-        'number.base': tPlugin(
-          'components.eastingNorthingField.eastingRequired',
-          language
-        ),
-        'number.min': tPlugin(
-          'components.eastingNorthingField.eastingRange',
-          language,
-          {
-            fieldLabel,
-            min: eastingMin,
-            max: eastingMax
-          }
-        ),
-        'number.max': tPlugin(
-          'components.eastingNorthingField.eastingRange',
-          language,
-          {
-            fieldLabel,
-            min: eastingMin,
-            max: eastingMax
-          }
-        ),
-        'number.precision': eastingDigitsMessage,
-        'number.integer': eastingDigitsMessage,
-        'number.unsafe': eastingDigitsMessage
-      })
+    const eastingValidationMessages: LanguageMessages = {
+      'any.required': tPlugin(
+        'components.eastingNorthingField.eastingRequired',
+        language
+      ),
+      'number.base': tPlugin(
+        'components.eastingNorthingField.eastingRequired',
+        language
+      ),
+      'number.min': tPlugin(
+        'components.eastingNorthingField.eastingRange',
+        language,
+        {
+          fieldLabel,
+          min: eastingMin,
+          max: eastingMax
+        }
+      ),
+      'number.max': tPlugin(
+        'components.eastingNorthingField.eastingRange',
+        language,
+        {
+          fieldLabel,
+          min: eastingMin,
+          max: eastingMax
+        }
+      ),
+      'number.precision': eastingDigitsMessage,
+      'number.integer': eastingDigitsMessage,
+      'number.unsafe': eastingDigitsMessage
+    }
 
-    const northingValidationMessages: LanguageMessages =
-      convertToLanguageMessages({
-        'any.required': tPlugin(
-          'components.eastingNorthingField.northingRequired',
-          language
-        ),
-        'number.base': tPlugin(
-          'components.eastingNorthingField.northingRequired',
-          language
-        ),
-        'number.min': tPlugin(
-          'components.eastingNorthingField.northingRange',
-          language,
-          {
-            fieldLabel,
-            min: northingMin,
-            max: northingMax
-          }
-        ),
-        'number.max': tPlugin(
-          'components.eastingNorthingField.northingRange',
-          language,
-          {
-            fieldLabel,
-            min: northingMin,
-            max: northingMax
-          }
-        ),
-        'number.precision': northingDigitsMessage,
-        'number.integer': northingDigitsMessage,
-        'number.unsafe': northingDigitsMessage
-      })
+    const northingValidationMessages: LanguageMessages = {
+      'any.required': tPlugin(
+        'components.eastingNorthingField.northingRequired',
+        language
+      ),
+      'number.base': tPlugin(
+        'components.eastingNorthingField.northingRequired',
+        language
+      ),
+      'number.min': tPlugin(
+        'components.eastingNorthingField.northingRange',
+        language,
+        {
+          fieldLabel,
+          min: northingMin,
+          max: northingMax
+        }
+      ),
+      'number.max': tPlugin(
+        'components.eastingNorthingField.northingRange',
+        language,
+        {
+          fieldLabel,
+          min: northingMin,
+          max: northingMax
+        }
+      ),
+      'number.precision': northingDigitsMessage,
+      'number.integer': northingDigitsMessage,
+      'number.unsafe': northingDigitsMessage
+    }
     return {
       eastingValidationMessages,
       northingValidationMessages

--- a/src/server/plugins/engine/components/EmailAddressField.ts
+++ b/src/server/plugins/engine/components/EmailAddressField.ts
@@ -40,7 +40,8 @@ export class EmailAddressField extends FormComponent {
       formSchema = formSchema.messages({
         'any.required': message,
         'string.empty': message,
-        'string.email': message
+        'string.email': message,
+        'string.unicode': message
       })
     } else if (options.customValidationMessages) {
       formSchema = formSchema.messages(options.customValidationMessages)

--- a/src/server/plugins/engine/components/FileUploadField.test.ts
+++ b/src/server/plugins/engine/components/FileUploadField.test.ts
@@ -649,7 +649,7 @@ describe('FileUploadField', () => {
               value: getFormData([]),
               errors: [
                 expect.objectContaining({
-                  text: 'Example file upload field must contain at least 1 items'
+                  text: 'You must upload 1 files or more'
                 })
               ]
             }
@@ -660,7 +660,7 @@ describe('FileUploadField', () => {
               value: getFormData(validState),
               errors: [
                 expect.objectContaining({
-                  text: 'Example file upload field must contain less than or equal to 2 items'
+                  text: 'You can only upload 2 files or less'
                 })
               ]
             }
@@ -683,7 +683,7 @@ describe('FileUploadField', () => {
               value: getFormData([]),
               errors: [
                 expect.objectContaining({
-                  text: 'Example file upload field must contain at least 1 items'
+                  text: 'You must upload 1 files or more'
                 })
               ]
             }
@@ -708,7 +708,7 @@ describe('FileUploadField', () => {
               value: getFormData([]),
               errors: [
                 expect.objectContaining({
-                  text: 'Example file upload field must contain 4 items'
+                  text: 'You must upload exactly 4 files'
                 })
               ]
             }
@@ -719,7 +719,7 @@ describe('FileUploadField', () => {
               value: getFormData(validState),
               errors: [
                 expect.objectContaining({
-                  text: 'Example file upload field must contain 4 items'
+                  text: 'You must upload exactly 4 files'
                 })
               ]
             }
@@ -730,7 +730,7 @@ describe('FileUploadField', () => {
               value: getFormData([...validState, ...validState]),
               errors: [
                 expect.objectContaining({
-                  text: 'Example file upload field must contain 4 items'
+                  text: 'You must upload exactly 4 files'
                 })
               ]
             }
@@ -790,7 +790,7 @@ describe('FileUploadField', () => {
               value: getFormData([]),
               errors: [
                 expect.objectContaining({
-                  text: 'Example file upload field must contain at least 1 items'
+                  text: 'You must upload 1 files or more'
                 })
               ]
             }
@@ -801,7 +801,7 @@ describe('FileUploadField', () => {
               value: getFormData(validState),
               errors: [
                 expect.objectContaining({
-                  text: 'Example file upload field must contain less than or equal to 2 items'
+                  text: 'You can only upload 2 files or less'
                 })
               ]
             }
@@ -834,7 +834,7 @@ describe('FileUploadField', () => {
               value: getFormData([]),
               errors: [
                 expect.objectContaining({
-                  text: 'Example file upload field must contain 4 items'
+                  text: 'You must upload exactly 4 files'
                 })
               ]
             }
@@ -845,7 +845,7 @@ describe('FileUploadField', () => {
               value: getFormData(validState),
               errors: [
                 expect.objectContaining({
-                  text: 'Example file upload field must contain 4 items'
+                  text: 'You must upload exactly 4 files'
                 })
               ]
             }
@@ -856,7 +856,7 @@ describe('FileUploadField', () => {
               value: getFormData([...validState, ...validState]),
               errors: [
                 expect.objectContaining({
-                  text: 'Example file upload field must contain 4 items'
+                  text: 'You must upload exactly 4 files'
                 })
               ]
             }

--- a/src/server/plugins/engine/components/FileUploadField.ts
+++ b/src/server/plugins/engine/components/FileUploadField.ts
@@ -35,7 +35,6 @@ import {
 } from '~/src/server/plugins/engine/types.js'
 import { render } from '~/src/server/plugins/nunjucks/index.js'
 import { type FormRequestPayload } from '~/src/server/routes/types.js'
-import { convertToLanguageMessages } from '~/src/server/utils/type-utils.js'
 import { resolveLanguage } from '~/src/server/utils/utils.js'
 
 export const uploadIdSchema = joi.string().uuid().required()
@@ -417,10 +416,10 @@ export class FileUploadField extends FormComponent {
   }
 
   static buildErrorMessages(language: string) {
-    return convertToLanguageMessages({
+    return {
       'array.min': tPlugin('validation.filesMin', language),
       'array.max': tPlugin('validation.filesMax', language),
       'array.length': tPlugin('validation.filesLength', language)
-    })
+    }
   }
 }

--- a/src/server/plugins/engine/components/FileUploadField.ts
+++ b/src/server/plugins/engine/components/FileUploadField.ts
@@ -5,11 +5,13 @@ import {
 import Boom from '@hapi/boom'
 import joi, { type ArraySchema } from 'joi'
 
+import { EN_GB } from '~/src/server/constants.js'
 import {
   FormComponent,
   isUploadState
 } from '~/src/server/plugins/engine/components/FormComponent.js'
 import { type RenderContext } from '~/src/server/plugins/engine/components/types.js'
+import { t as tPlugin } from '~/src/server/plugins/engine/i18n/index.js'
 import { type Translator } from '~/src/server/plugins/engine/i18n/types.js'
 import { InvalidComponentStateError } from '~/src/server/plugins/engine/pageControllers/errors.js'
 import { messageTemplate } from '~/src/server/plugins/engine/pageControllers/validationOptions.js'
@@ -33,6 +35,7 @@ import {
 } from '~/src/server/plugins/engine/types.js'
 import { render } from '~/src/server/plugins/nunjucks/index.js'
 import { type FormRequestPayload } from '~/src/server/routes/types.js'
+import { convertToLanguageMessages } from '~/src/server/utils/type-utils.js'
 import { resolveLanguage } from '~/src/server/utils/utils.js'
 
 export const uploadIdSchema = joi.string().uuid().required()
@@ -141,6 +144,8 @@ export class FileUploadField extends FormComponent {
     } else {
       formSchema = formSchema.length(schema.length)
     }
+
+    formSchema = formSchema.messages(FileUploadField.buildErrorMessages(EN_GB))
 
     this.formSchema = formSchema.items(formItemSchema)
     this.stateSchema = formSchema
@@ -300,6 +305,13 @@ export class FileUploadField extends FormComponent {
     return isUploadState(value)
   }
 
+  getValidationMessagesOverride(translator: Translator) {
+    const { language } = translator
+    return {
+      [this.name]: FileUploadField.buildErrorMessages(language)
+    }
+  }
+
   /**
    * For error preview page that shows all possible errors on a component
    */
@@ -402,5 +414,13 @@ export class FileUploadField extends FormComponent {
         }
       ]
     }
+  }
+
+  static buildErrorMessages(language: string) {
+    return convertToLanguageMessages({
+      'array.min': tPlugin('validation.filesMin', language),
+      'array.max': tPlugin('validation.filesMax', language),
+      'array.length': tPlugin('validation.filesLength', language)
+    })
   }
 }

--- a/src/server/plugins/engine/components/GeospatialField.test.ts
+++ b/src/server/plugins/engine/components/GeospatialField.test.ts
@@ -279,7 +279,7 @@ describe('GeospatialField', () => {
               value: getFormData([]),
               errors: [
                 expect.objectContaining({
-                  text: 'validation.features.min' // 'Define at least 1 features'
+                  text: 'Define at least 1 features'
                 })
               ]
             }
@@ -329,7 +329,7 @@ describe('GeospatialField', () => {
               value: getFormData([]),
               errors: [
                 expect.objectContaining({
-                  text: 'validation.features.min' // 'Define at least 2 features'
+                  text: 'Define at least 2 features'
                 })
               ]
             }
@@ -351,7 +351,7 @@ describe('GeospatialField', () => {
               value: getFormData(validSingleState),
               errors: [
                 expect.objectContaining({
-                  text: 'validation.features.min' // 'Define at least 2 features'
+                  text: 'Define at least 2 features'
                 })
               ]
             }
@@ -384,7 +384,7 @@ describe('GeospatialField', () => {
               value: getFormData([]),
               errors: [
                 expect.objectContaining({
-                  text: 'validation.features.min' // 'Define at least 1 features'
+                  text: 'Define at least 1 features'
                 })
               ]
             }
@@ -412,7 +412,7 @@ describe('GeospatialField', () => {
               value: getFormData(validState),
               errors: [
                 expect.objectContaining({
-                  text: 'validation.features.max' // 'Only 1 features can be defined'
+                  text: 'Only 1 features can be defined'
                 })
               ]
             }
@@ -439,7 +439,7 @@ describe('GeospatialField', () => {
               value: getFormData([]),
               errors: [
                 expect.objectContaining({
-                  text: 'validation.features.length' // 'Define exactly 1 features'
+                  text: 'Define exactly 1 features'
                 })
               ]
             }
@@ -467,7 +467,7 @@ describe('GeospatialField', () => {
               value: getFormData(validState),
               errors: [
                 expect.objectContaining({
-                  text: 'validation.features.length' // 'Define exactly 1 features'
+                  text: 'Define exactly 1 features'
                 })
               ]
             }
@@ -513,7 +513,7 @@ describe('GeospatialField', () => {
               value: getFormData([]),
               errors: [
                 expect.objectContaining({
-                  text: 'validation.features.min' // 'Define at least 2 features'
+                  text: 'Define at least 2 features'
                 })
               ]
             }
@@ -530,7 +530,7 @@ describe('GeospatialField', () => {
               value: getFormData(validSingleState),
               errors: [
                 expect.objectContaining({
-                  text: 'validation.features.min' // 'Define at least 2 features'
+                  text: 'Define at least 2 features'
                 })
               ]
             }
@@ -581,7 +581,7 @@ describe('GeospatialField', () => {
               value: getFormData(validState),
               errors: [
                 expect.objectContaining({
-                  text: 'validation.features.max' // 'Only 1 features can be defined'
+                  text: 'Only 1 features can be defined'
                 })
               ]
             }
@@ -608,7 +608,7 @@ describe('GeospatialField', () => {
               value: getFormData([]),
               errors: [
                 expect.objectContaining({
-                  text: 'validation.features.length' // 'Define exactly 1 features'
+                  text: 'Define exactly 1 features'
                 })
               ]
             }
@@ -631,7 +631,7 @@ describe('GeospatialField', () => {
               value: getFormData(validState),
               errors: [
                 expect.objectContaining({
-                  text: 'validation.features.length' // Define exactly 1 features
+                  text: 'Define exactly 1 features'
                 })
               ]
             }
@@ -722,7 +722,7 @@ describe('GeospatialField', () => {
         }
       ]
 
-      const mockT = jest.fn().mockReturnValue('translated country error')
+      const mockT = jest.fn().mockReturnValue('Translated country')
       const mockTranslator = { ...stubTranslator, t: mockT }
 
       const result = collection.validate(getFormData(invalidSingleState))
@@ -735,12 +735,12 @@ describe('GeospatialField', () => {
 
       expect(mockT).toHaveBeenCalledWith(
         'components.geospatialField.validation.wrongCountry',
-        { count: 1, country: 'Scotland' }
+        { count: 1, country: 'Translated country' }
       )
       expect(viewErrors).toEqual([
         expect.objectContaining({
           href: '#description_0',
-          text: 'translated country error'
+          text: 'Translated country'
         })
       ])
     })

--- a/src/server/plugins/engine/components/GeospatialField.ts
+++ b/src/server/plugins/engine/components/GeospatialField.ts
@@ -125,7 +125,12 @@ export class GeospatialField extends FormComponent {
         err.href = `#description_${err.path[1]}`
         err.text = translator.t(
           'components.geospatialField.validation.wrongCountry',
-          { count: Number(err.path[1]) + 1, country: err.context.country }
+          {
+            count: Number(err.path[1]) + 1,
+            country: translator.t(
+              `common.${(err.context.country as string).toLowerCase()}`
+            )
+          }
         )
       }
     })

--- a/src/server/plugins/engine/components/LatLongField.ts
+++ b/src/server/plugins/engine/components/LatLongField.ts
@@ -31,7 +31,6 @@ import {
   type FormSubmissionError,
   type FormSubmissionState
 } from '~/src/server/plugins/engine/types.js'
-import { convertToLanguageMessages } from '~/src/server/utils/type-utils.js'
 
 // Precision constants
 // UK latitude/longitude requires high precision for accurate location (within ~11mm)
@@ -267,14 +266,13 @@ export class LatLongField extends FormComponent {
   ) {
     const fieldLabel = lowerFirst(label)
 
-    const customValidationMessages: LanguageMessages =
-      convertToLanguageMessages({
-        'number.precision': tPlugin(
-          'components.latLongField.precision',
-          language
-        ),
-        'number.unsafe': tPlugin('components.latLongField.notANumber', language)
-      })
+    const customValidationMessages: LanguageMessages = {
+      'number.precision': tPlugin(
+        'components.latLongField.precision',
+        language
+      ),
+      'number.unsafe': tPlugin('components.latLongField.notANumber', language)
+    }
 
     const latitudeRangeMessage = tPlugin(
       'components.latLongField.latitudeRange',
@@ -287,7 +285,7 @@ export class LatLongField extends FormComponent {
       { fieldLabel, min: longitudeMin, max: longitudeMax }
     )
 
-    const latitudeMessages: LanguageMessages = convertToLanguageMessages({
+    const latitudeMessages: LanguageMessages = {
       ...customValidationMessages,
       'any.required': tPlugin(
         'components.latLongField.latitudeRequired',
@@ -298,9 +296,9 @@ export class LatLongField extends FormComponent {
       }),
       'number.min': latitudeRangeMessage,
       'number.max': latitudeRangeMessage
-    })
+    }
 
-    const longitudeMessages: LanguageMessages = convertToLanguageMessages({
+    const longitudeMessages: LanguageMessages = {
       ...customValidationMessages,
       'any.required': tPlugin(
         'components.latLongField.longitudeRequired',
@@ -315,7 +313,7 @@ export class LatLongField extends FormComponent {
       ),
       'number.min': longitudeRangeMessage,
       'number.max': longitudeRangeMessage
-    })
+    }
 
     return {
       latitudeMessages,

--- a/src/server/plugins/engine/components/LocationFieldBase.test.ts
+++ b/src/server/plugins/engine/components/LocationFieldBase.test.ts
@@ -5,11 +5,12 @@ import { type LanguageMessages } from 'joi'
 import { LocationFieldBase } from '~/src/server/plugins/engine/components/LocationFieldBase.js'
 import { FormModel } from '~/src/server/plugins/engine/models/FormModel.js'
 import { stubTranslator } from '~/src/server/plugins/engine/pageControllers/__stubs__/translator.js'
+import { type Translator } from '~/src/server/plugins/engine/types/index.js'
 import definition from '~/test/form/definitions/blank.js'
 import { getFormData } from '~/test/helpers/component-helpers.js'
 
 class TestLocationField extends LocationFieldBase {
-  protected getValidationConfig() {
+  protected getValidationConfig(_translator: Translator) {
     return {
       pattern: /^TEST\d{4}$/i,
       patternErrorMessage: 'Enter a valid test code like TEST1234',

--- a/src/server/plugins/engine/components/LocationFieldBase.ts
+++ b/src/server/plugins/engine/components/LocationFieldBase.ts
@@ -20,7 +20,6 @@ import {
   type FormStateValue,
   type FormSubmissionState
 } from '~/src/server/plugins/engine/types.js'
-import { convertToLanguageMessages } from '~/src/server/utils/type-utils.js'
 
 interface LocationFieldOptions {
   instructionText?: string
@@ -68,11 +67,11 @@ export abstract class LocationFieldBase extends FormComponent {
     const config = this.getValidationConfig(undefined)
     const requiredMessage = config.requiredMessage ?? messageTemplate.required
 
-    const messages = convertToLanguageMessages({
+    const messages = {
       'any.required': requiredMessage,
       'string.empty': requiredMessage,
       'string.pattern.base': config.patternErrorMessage
-    })
+    } as LanguageMessages
 
     let formSchema = joi
       .string()
@@ -139,13 +138,13 @@ export abstract class LocationFieldBase extends FormComponent {
     const { t } = translator
     const config = this.getValidationConfig(translator)
     return {
-      [this.name]: convertToLanguageMessages({
+      [this.name]: {
         'any.required':
           config.requiredMessage ?? buildValidationMessages(t).objectRequired,
         'string.empty':
           config.requiredMessage ?? buildValidationMessages(t).objectRequired,
         'string.pattern.base': config.patternErrorMessage
-      })
+      } as LanguageMessages
     }
   }
 

--- a/src/server/plugins/engine/components/LocationFieldBase.ts
+++ b/src/server/plugins/engine/components/LocationFieldBase.ts
@@ -11,7 +11,9 @@ import {
 } from '~/src/server/plugins/engine/components/FormComponent.js'
 import { addClassOptionIfNone } from '~/src/server/plugins/engine/components/helpers/index.js'
 import { type RenderContext } from '~/src/server/plugins/engine/components/types.js'
+import { buildValidationMessages } from '~/src/server/plugins/engine/i18n/buildValidationMessages.js'
 import { messageTemplate } from '~/src/server/plugins/engine/pageControllers/validationOptions.js'
+import { type Translator } from '~/src/server/plugins/engine/types/index.js'
 import {
   type ErrorMessageTemplateList,
   type FormState,
@@ -43,7 +45,9 @@ export abstract class LocationFieldBase extends FormComponent {
   declare stateSchema: StringSchema
   instructionText?: string
 
-  protected abstract getValidationConfig(): ValidationConfig
+  protected abstract getValidationConfig(
+    translator: Translator | undefined
+  ): ValidationConfig
   protected abstract getErrorTemplates(): {
     type: string
     template: JoiExpression
@@ -61,7 +65,7 @@ export abstract class LocationFieldBase extends FormComponent {
 
     addClassOptionIfNone(locationOptions, 'govuk-input--width-10')
 
-    const config = this.getValidationConfig()
+    const config = this.getValidationConfig(undefined)
     const requiredMessage = config.requiredMessage ?? messageTemplate.required
 
     const messages = convertToLanguageMessages({
@@ -131,8 +135,22 @@ export abstract class LocationFieldBase extends FormComponent {
     return viewModel
   }
 
+  getValidationMessagesOverride(translator: Translator) {
+    const { t } = translator
+    const config = this.getValidationConfig(translator)
+    return {
+      [this.name]: convertToLanguageMessages({
+        'any.required':
+          config.requiredMessage ?? buildValidationMessages(t).objectRequired,
+        'string.empty':
+          config.requiredMessage ?? buildValidationMessages(t).objectRequired,
+        'string.pattern.base': config.patternErrorMessage
+      })
+    }
+  }
+
   getAllPossibleErrors(): ErrorMessageTemplateList {
-    const config = this.getValidationConfig()
+    const config = this.getValidationConfig(undefined)
 
     return {
       baseErrors: [

--- a/src/server/plugins/engine/components/MonthYearField.ts
+++ b/src/server/plugins/engine/components/MonthYearField.ts
@@ -158,16 +158,18 @@ export class MonthYearField extends FormComponent {
 
   getValidationMessagesOverride(translator: Translator) {
     const { t } = translator
+    const messages = convertToLanguageMessages({
+      'any.required': buildValidationMessages(t).objectMissing,
+      'number.base': buildValidationMessages(t).objectMissing,
+      'number.precision': buildValidationMessages(t).dateFormat,
+      'number.integer': buildValidationMessages(t).dateFormat,
+      'number.unsafe': buildValidationMessages(t).dateFormat,
+      'number.min': buildValidationMessages(t).dateFormat,
+      'number.max': buildValidationMessages(t).dateFormat
+    })
     return {
-      [this.name]: convertToLanguageMessages({
-        'any.required': buildValidationMessages(t).objectMissing,
-        'number.base': buildValidationMessages(t).objectMissing,
-        'number.precision': buildValidationMessages(t).dateFormat,
-        'number.integer': buildValidationMessages(t).dateFormat,
-        'number.unsafe': buildValidationMessages(t).dateFormat,
-        'number.min': buildValidationMessages(t).dateFormat,
-        'number.max': buildValidationMessages(t).dateFormat
-      })
+      [`${this.name}__month`]: messages,
+      [`${this.name}__year`]: messages
     }
   }
 

--- a/src/server/plugins/engine/components/MonthYearField.ts
+++ b/src/server/plugins/engine/components/MonthYearField.ts
@@ -31,7 +31,6 @@ import {
   type FormSubmissionState
 } from '~/src/server/plugins/engine/types.js'
 import { formatDateForLanguage } from '~/src/server/plugins/payment/helper.js'
-import { convertToLanguageMessages } from '~/src/server/utils/type-utils.js'
 
 export class MonthYearField extends FormComponent {
   declare options: MonthYearFieldComponent['options']
@@ -49,16 +48,15 @@ export class MonthYearField extends FormComponent {
 
     const isRequired = options.required !== false
 
-    const customValidationMessages: LanguageMessages =
-      convertToLanguageMessages({
-        'any.required': messageTemplate.objectMissing,
-        'number.base': messageTemplate.objectMissing,
-        'number.precision': messageTemplate.dateFormat,
-        'number.integer': messageTemplate.dateFormat,
-        'number.unsafe': messageTemplate.dateFormat,
-        'number.min': messageTemplate.dateFormat,
-        'number.max': messageTemplate.dateFormat
-      })
+    const customValidationMessages = {
+      'any.required': messageTemplate.objectMissing,
+      'number.base': messageTemplate.objectMissing,
+      'number.precision': messageTemplate.dateFormat,
+      'number.integer': messageTemplate.dateFormat,
+      'number.unsafe': messageTemplate.dateFormat,
+      'number.min': messageTemplate.dateFormat,
+      'number.max': messageTemplate.dateFormat
+    } as LanguageMessages
 
     this.collection = new ComponentCollection(
       [
@@ -158,7 +156,7 @@ export class MonthYearField extends FormComponent {
 
   getValidationMessagesOverride(translator: Translator) {
     const { t } = translator
-    const messages = convertToLanguageMessages({
+    const messages = {
       'any.required': buildValidationMessages(t).objectMissing,
       'number.base': buildValidationMessages(t).objectMissing,
       'number.precision': buildValidationMessages(t).dateFormat,
@@ -166,7 +164,7 @@ export class MonthYearField extends FormComponent {
       'number.unsafe': buildValidationMessages(t).dateFormat,
       'number.min': buildValidationMessages(t).dateFormat,
       'number.max': buildValidationMessages(t).dateFormat
-    })
+    } as LanguageMessages
     return {
       [`${this.name}__month`]: messages,
       [`${this.name}__year`]: messages

--- a/src/server/plugins/engine/components/NationalGridFieldNumberField.ts
+++ b/src/server/plugins/engine/components/NationalGridFieldNumberField.ts
@@ -1,14 +1,16 @@
 import { type NationalGridFieldNumberFieldComponent } from '@defra/forms-model'
 
+import { EN_GB } from '~/src/server/constants.js'
 import { LocationFieldBase } from '~/src/server/plugins/engine/components/LocationFieldBase.js'
 import { createLowerFirstExpression } from '~/src/server/plugins/engine/components/helpers/index.js'
 import { t } from '~/src/server/plugins/engine/i18n/index.js'
+import { type Translator } from '~/src/server/plugins/engine/i18n/types.js'
 import { type ErrorMessageTemplateList } from '~/src/server/plugins/engine/types.js'
 
 export class NationalGridFieldNumberField extends LocationFieldBase {
   declare options: NationalGridFieldNumberFieldComponent['options']
 
-  protected getValidationConfig() {
+  protected getValidationConfig(translator: Translator | undefined) {
     // Regex for OS national grid field references (NGFR)
     // Validates specific valid OS grid letter combinations with:
     // - 2 letters & 8 digits in 2 blocks of 4 e.g. ST 6789 6789
@@ -18,10 +20,14 @@ export class NationalGridFieldNumberField extends LocationFieldBase {
     return {
       pattern,
       patternErrorMessage: createLowerFirstExpression(
-        t('components.nationalGridField.pattern', 'en-GB')
+        translator
+          ? translator.t('components.nationalGridField.pattern')
+          : t('components.nationalGridField.pattern', EN_GB)
       ),
       requiredMessage: createLowerFirstExpression(
-        t('components.nationalGridField.required', 'en-GB')
+        translator
+          ? translator.t('components.nationalGridField.required')
+          : t('components.nationalGridField.required', EN_GB)
       )
     }
   }

--- a/src/server/plugins/engine/components/NumberField.ts
+++ b/src/server/plugins/engine/components/NumberField.ts
@@ -1,5 +1,9 @@
 import { type NumberFieldComponent } from '@defra/forms-model'
-import joi, { type CustomValidator, type NumberSchema } from 'joi'
+import joi, {
+  type CustomValidator,
+  type LanguageMessages,
+  type NumberSchema
+} from 'joi'
 
 import {
   FormComponent,
@@ -15,7 +19,6 @@ import {
   type FormStateValue,
   type FormSubmissionState
 } from '~/src/server/plugins/engine/types.js'
-import { convertToLanguageMessages } from '~/src/server/utils/type-utils.js'
 
 export class NumberField extends FormComponent {
   declare options: NumberFieldComponent['options']
@@ -136,14 +139,14 @@ export class NumberField extends FormComponent {
   getValidationMessagesOverride(translator: Translator) {
     const { t } = translator
     return {
-      [this.name]: convertToLanguageMessages({
+      [this.name]: {
         'any.required': buildValidationMessages(t).objectRequired,
         'number.base': buildValidationMessages(t).objectMissing,
         'number.precision': buildValidationMessages(t).numberPrecision,
         'number.integer': buildValidationMessages(t).numberInteger,
         'number.min': buildValidationMessages(t).numberMin,
         'number.max': buildValidationMessages(t).numberMax
-      })
+      } as LanguageMessages
     }
   }
 

--- a/src/server/plugins/engine/components/NumberField.ts
+++ b/src/server/plugins/engine/components/NumberField.ts
@@ -6,13 +6,16 @@ import {
   isFormValue
 } from '~/src/server/plugins/engine/components/FormComponent.js'
 import { type RenderContext } from '~/src/server/plugins/engine/components/types.js'
+import { buildValidationMessages } from '~/src/server/plugins/engine/i18n/buildValidationMessages.js'
 import { messageTemplate } from '~/src/server/plugins/engine/pageControllers/validationOptions.js'
+import { type Translator } from '~/src/server/plugins/engine/types/index.js'
 import {
   type ErrorMessageTemplateList,
   type FormState,
   type FormStateValue,
   type FormSubmissionState
 } from '~/src/server/plugins/engine/types.js'
+import { convertToLanguageMessages } from '~/src/server/utils/type-utils.js'
 
 export class NumberField extends FormComponent {
   declare options: NumberFieldComponent['options']
@@ -128,6 +131,20 @@ export class NumberField extends FormComponent {
 
   isValue(value?: FormStateValue | FormState) {
     return NumberField.isNumber(value)
+  }
+
+  getValidationMessagesOverride(translator: Translator) {
+    const { t } = translator
+    return {
+      [this.name]: convertToLanguageMessages({
+        'any.required': buildValidationMessages(t).objectRequired,
+        'number.base': buildValidationMessages(t).objectMissing,
+        'number.precision': buildValidationMessages(t).numberPrecision,
+        'number.integer': buildValidationMessages(t).numberInteger,
+        'number.min': buildValidationMessages(t).numberMin,
+        'number.max': buildValidationMessages(t).numberMax
+      })
+    }
   }
 
   /**

--- a/src/server/plugins/engine/components/OsGridRefField.ts
+++ b/src/server/plugins/engine/components/OsGridRefField.ts
@@ -1,14 +1,16 @@
 import { type OsGridRefFieldComponent } from '@defra/forms-model'
 
+import { EN_GB } from '~/src/server/constants.js'
 import { LocationFieldBase } from '~/src/server/plugins/engine/components/LocationFieldBase.js'
 import { createLowerFirstExpression } from '~/src/server/plugins/engine/components/helpers/index.js'
 import { t } from '~/src/server/plugins/engine/i18n/index.js'
+import { type Translator } from '~/src/server/plugins/engine/types/index.js'
 import { type ErrorMessageTemplateList } from '~/src/server/plugins/engine/types.js'
 
 export class OsGridRefField extends LocationFieldBase {
   declare options: OsGridRefFieldComponent['options']
 
-  protected getValidationConfig() {
+  protected getValidationConfig(translator: Translator | undefined) {
     // Regex for OS national grid references (NGR)
     // Validates specific valid OS grid letter combinations with:
     // - 2 letters & 6 digits in 2 blocks of 3 e.g. ST 678 678
@@ -21,10 +23,14 @@ export class OsGridRefField extends LocationFieldBase {
     return {
       pattern,
       patternErrorMessage: createLowerFirstExpression(
-        t('components.osGridRefField.pattern', 'en-GB')
+        translator
+          ? translator.t('components.osGridRefField.pattern')
+          : t('components.osGridRefField.pattern', EN_GB)
       ),
       requiredMessage: createLowerFirstExpression(
-        t('components.osGridRefField.required', 'en-GB')
+        translator
+          ? translator.t('components.osGridRefField.required')
+          : t('components.osGridRefField.required', EN_GB)
       )
     }
   }

--- a/src/server/plugins/engine/components/UkAddressField.ts
+++ b/src/server/plugins/engine/components/UkAddressField.ts
@@ -214,7 +214,7 @@ export class UkAddressField extends FormComponent {
 
         /**
          * For screen readers, only hide legend visually. This can be overridden
-         * by single component {@link QuestionPageController | `showTitle` handling}
+         * by single component (see QuestionPageController and showTitle handling)
          */
         classes: options.hideTitle
           ? 'govuk-visually-hidden'

--- a/src/server/plugins/engine/helpers.ts
+++ b/src/server/plugins/engine/helpers.ts
@@ -301,6 +301,7 @@ export function checkEmailAddressForLiveFormSubmission(
 
 /**
  * Parses the errors from {@link Schema.validate} so they can be rendered by govuk-frontend templates
+ * @param language - the target language for translations
  * @param [details] - provided by {@link Schema.validate}
  */
 export function getErrors(

--- a/src/server/plugins/engine/i18n/buildValidationMessages.ts
+++ b/src/server/plugins/engine/i18n/buildValidationMessages.ts
@@ -56,13 +56,16 @@ export function buildValidationMessages(t: (key: string) => string) {
     dateMin: t('components.dateField.validation.dateMin'),
     dateMax: t('components.dateField.validation.dateMax'),
 
-    unicode: 'validation.unicode',
-    arrayMin: 'validation.array.min',
-    arrayMax: 'validation.array.max',
-    arrayLength: 'validation.array.length',
-    featuresMin: 'validation.features.min',
-    featuresMax: 'validation.features.max',
-    featuresLength: 'validation.features.length'
+    unicode: t('validation.unicode'),
+    arrayMin: t('validation.arrayMin'),
+    arrayMax: t('validation.arrayMax'),
+    arrayLength: t('validation.arrayLength'),
+    featuresMin: t('validation.featuresMin'),
+    featuresMax: t('validation.featuresMax'),
+    featuresLength: t('validation.featuresLength'),
+    filesMin: t('validation.filesMin'),
+    filesMax: t('validation.filesMax'),
+    filesLength: t('validation.filesLength')
   }
 }
 

--- a/src/server/plugins/engine/i18n/translations/cy.json
+++ b/src/server/plugins/engine/i18n/translations/cy.json
@@ -14,7 +14,17 @@
     "numberInteger": "Rhaid i {{#label}} fod yn rhif cyfan",
     "numberMin": "Rhaid i {{#label}} fod yn {{#limit}} neu uwch",
     "numberMax": "Rhaid i {{#label}} fod yn {{#limit}} neu is",
-    "maxWords": "Rhaid i {{#label}} fod yn {{#limit}} o eiriau neu lai"
+    "maxWords": "Rhaid i {{#label}} fod yn {{#limit}} o eiriau neu lai",
+    "unicode": "Mae {{#label}} yn cynnwys nodau annilys, er enghraifft, dashes hirion",
+    "arrayMin": "Dewiswch o leiaf {{#limit}} o opsiynau o'r rhestr",
+    "arrayMax": "Dim ond {{#limit}} y gellir eu dewis o'r rhestr",
+    "arrayLength": "Dewiswch ddim ond {{#limit}} o opsiynau o'r rhestr",
+    "featuresMin": "Diffiniwch o leiaf {{#limit}} nodwedd",
+    "featuresMax": "Dim ond {{#limit}} nodwedd y gellir eu diffinio",
+    "featuresLength": "Diffiniwch nodweddion {{#limit}} yn union",
+    "filesMin": "Rhaid i chi uwchlwytho {{#limit}} o ffeiliau neu fwy",
+    "filesMax": "Dim ond {{#limit}} o ffeiliau neu lai y gallwch eu huwchlwytho",
+    "filesLength": "Rhaid i chi uwchlwytho'n union {{#limit}} o ffeiliau"
   },
 
   "errors": {
@@ -31,7 +41,11 @@
     "draft": "ddrafft",
     "live": "fyw",
     "or": "neu",
-    "and": "a"
+    "and": "a",
+    "england": "Lloegr",
+    "wales": "Cymru",
+    "northernIreland": "Gogledd Iwerddon",
+    "scotland": "Yr Alban"
   },
 
   "pages": {
@@ -252,7 +266,7 @@
       "yes": "Ie",
       "no": "Nage",
       "validation": {
-        "selectYesNoRequired": "{{#label}} - dewiswch ie neu na"
+        "selectYesNoRequired": "{{#label}} - dewiswch ie neu nage"
       }
     },
 

--- a/src/server/plugins/engine/i18n/translations/cy.json
+++ b/src/server/plugins/engine/i18n/translations/cy.json
@@ -45,7 +45,8 @@
     "england": "Lloegr",
     "wales": "Cymru",
     "northernIreland": "Gogledd Iwerddon",
-    "scotland": "Yr Alban"
+    "scotland": "Yr Alban",
+    "sendFeedback": "Anfon adborth"
   },
 
   "pages": {

--- a/src/server/plugins/engine/i18n/translations/en-GB.json
+++ b/src/server/plugins/engine/i18n/translations/en-GB.json
@@ -45,7 +45,8 @@
     "england": "England",
     "wales": "Wales",
     "northernIreland": "Northern Ireland",
-    "scotland": "Scotland"
+    "scotland": "Scotland",
+    "sendFeedback": "Send feedback"
   },
 
   "pages": {

--- a/src/server/plugins/engine/i18n/translations/en-GB.json
+++ b/src/server/plugins/engine/i18n/translations/en-GB.json
@@ -14,7 +14,17 @@
     "numberInteger": "{{#label}} must be a whole number",
     "numberMin": "{{#label}} must be {{#limit}} or higher",
     "numberMax": "{{#label}} must be {{#limit}} or lower",
-    "maxWords": "{{#label}} must be {{#limit}} words or fewer"
+    "maxWords": "{{#label}} must be {{#limit}} words or fewer",
+    "unicode": "{{#label}} includes invalid characters, for example, long dashes",
+    "arrayMin": "Select at least {{#limit}} options from the list",
+    "arrayMax": "Only {{#limit}} can be selected from the list",
+    "arrayLength": "Select only {{#limit}} options from the list",
+    "featuresMin": "Define at least {{#limit}} features",
+    "featuresMax": "Only {{#limit}} features can be defined",
+    "featuresLength": "Define exactly {{#limit}} features",
+    "filesMin": "You must upload {{#limit}} files or more",
+    "filesMax": "You can only upload {{#limit}} files or less",
+    "filesLength": "You must upload exactly {{#limit}} files"
   },
 
   "errors": {
@@ -31,7 +41,11 @@
     "draft": "draft",
     "live": "live",
     "or": "or",
-    "and": "and"
+    "and": "and",
+    "england": "England",
+    "wales": "Wales",
+    "northernIreland": "Northern Ireland",
+    "scotland": "Scotland"
   },
 
   "pages": {

--- a/src/server/plugins/engine/index.ts
+++ b/src/server/plugins/engine/index.ts
@@ -28,6 +28,7 @@ export {
   loadFormTranslations
 } from '~/src/server/plugins/engine/i18n/createFormTranslator.js'
 export { extractBaseTranslations } from '~/src/server/plugins/engine/i18n/extractBaseTranslations.js'
+export { applyUrlParam } from '~/src/server/plugins/nunjucks/filters/applyUrlParam.js'
 
 const globals = {
   checkComponentTemplates,

--- a/src/server/plugins/engine/pageControllers/validationOptions.ts
+++ b/src/server/plugins/engine/pageControllers/validationOptions.ts
@@ -58,7 +58,21 @@ export const messages: LanguageMessagesExt = {
   'date.min': messageTemplate.dateMin,
   'date.max': messageTemplate.dateMax,
 
-  'object.invalidjson': messageTemplate.format
+  'array.min': messageTemplate.arrayMin,
+  'array.max': messageTemplate.arrayMax,
+  'array.length': messageTemplate.arrayLength,
+
+  'features.min': messageTemplate.featuresMin,
+  'features.max': messageTemplate.featuresMax,
+  'features.length': messageTemplate.featuresLength,
+
+  'files.min': messageTemplate.filesMin,
+  'files.max': messageTemplate.filesMax,
+  'filees.length': messageTemplate.filesLength,
+
+  'object.invalidjson': messageTemplate.format,
+
+  'phoneNumber.invalid': messageTemplate.format
 }
 
 export const messagesPre: LanguageMessages =
@@ -76,6 +90,7 @@ export function buildLanguageMessages(
     'string.email': vm.format,
     'string.pattern.base': vm.pattern,
     'string.maxWords': vm.maxWords,
+    'string.unicode': vm.unicode,
     'number.base': vm.number,
     'number.precision': vm.numberPrecision,
     'number.integer': vm.numberInteger,
@@ -91,7 +106,17 @@ export function buildLanguageMessages(
     'date.format': vm.dateFormat,
     'date.min': vm.dateMin,
     'date.max': vm.dateMax,
-    'object.invalidjson': vm.format
+    'array.min': vm.arrayMin,
+    'array.max': vm.arrayMax,
+    'array.length': vm.arrayLength,
+    'features.min': vm.featuresMin,
+    'features.max': vm.featuresMax,
+    'features.length': vm.featuresLength,
+    'files.min': vm.filesMin,
+    'files.max': vm.filesMax,
+    'files.length': vm.filesLength,
+    'object.invalidjson': vm.format,
+    'phoneNumber.invalid': vm.format
   } as unknown as LanguageMessages
 }
 

--- a/src/server/plugins/postcode-lookup/models/index.js
+++ b/src/server/plugins/postcode-lookup/models/index.js
@@ -473,8 +473,7 @@ export async function selectViewModel(data, translator, payload, err) {
   const { session, apiKey } = data
   const { details, initial } = session
   const { postcodeQuery, buildingNameQuery } = details
-  const language = translator.language
-  const { t, tComponent, tForm } = translator
+  const { language, t, tComponent, tForm } = translator
 
   const {
     hasAddresses,
@@ -556,6 +555,7 @@ export async function selectViewModel(data, translator, payload, err) {
     addressesFoundText,
     noAddressFoundText,
     buttons: { continueButton, manualLink },
+    t,
     language,
     ...selector
   }

--- a/src/server/plugins/postcode-lookup/views/postcode-lookup-details.html
+++ b/src/server/plugins/postcode-lookup/views/postcode-lookup-details.html
@@ -33,7 +33,7 @@
             <!-- Postcode lookup select -->
             <!-- Postcode lookup details display -->
             {%- set detailsHtml -%}
-              <strong>{{ details.postcodeQuery }}</strong>{% if details.buildingNameQuery %} {{ t('common.or')}} <strong>{{ details.buildingNameQuery }}</strong>{% endif %}
+              <strong>{{ details.postcodeQuery }}</strong>{% if details.buildingNameQuery %} {{ t('common.and')}} <strong>{{ details.buildingNameQuery }}</strong>{% endif %}
             {%- endset -%}
 
             {% if hasAddresses %}

--- a/src/server/utils/type-utils.ts
+++ b/src/server/utils/type-utils.ts
@@ -1,14 +1,4 @@
-import Joi, {
-  type JoiExpression,
-  type LanguageMessages,
-  type LanguageMessagesExt
-} from 'joi'
-
-export function convertToLanguageMessages(
-  extLanguageMessages: LanguageMessagesExt
-): LanguageMessages {
-  return extLanguageMessages as unknown as LanguageMessages
-}
+import Joi, { type JoiExpression } from 'joi'
 
 export function createJoiExpression(expr: string): JoiExpression {
   return Joi.expression(expr) as unknown as JoiExpression

--- a/test/form/definitions/fields-required-translated.js
+++ b/test/form/definitions/fields-required-translated.js
@@ -1,0 +1,524 @@
+import {
+  ComponentType,
+  ControllerPath,
+  ControllerType
+} from '@defra/forms-model'
+
+export default /** @satisfies {FormDefinition} */ ({
+  name: 'Fields required',
+  startPage: '/components',
+  pages: /** @type {const} */ ([
+    {
+      id: '4af89edc-2424-4fed-937c-500525667b96',
+      path: '/components',
+      title: 'Fields required',
+      components: [
+        {
+          id: 'f4c68ce0-d868-43cb-87df-b80018dec23a',
+          type: ComponentType.TextField,
+          name: 'textField',
+          title: 'Text field',
+          hint: 'Help text',
+          options: {},
+          schema: {
+            max: 30
+          }
+        },
+        {
+          id: '9d83327b-3783-430c-aef8-c73875672cae',
+          type: ComponentType.MultilineTextField,
+          name: 'multilineTextField',
+          title: 'Multiline text field',
+          hint: 'Help text',
+          options: {},
+          schema: {
+            max: 30
+          }
+        },
+        {
+          id: '33bd0fbe-52d2-4fb4-94d1-b036747a9d38',
+          type: ComponentType.NumberField,
+          name: 'numberField',
+          title: 'Number field',
+          options: {},
+          schema: {
+            max: 2000
+          }
+        },
+        {
+          id: '03d0d43f-4dbb-4c52-9291-be63c4636748',
+          type: ComponentType.DatePartsField,
+          name: 'datePartsField',
+          title: 'Date parts field',
+          options: {}
+        },
+        {
+          id: 'ba70dabf-ea01-4643-808c-24638743fcf7',
+          type: ComponentType.MonthYearField,
+          name: 'monthYearField',
+          title: 'Month year field',
+          options: {}
+        },
+        {
+          id: '7d4660a1-2e5b-48d7-854d-3bb1fe75c2c3',
+          type: ComponentType.YesNoField,
+          name: 'yesNoField',
+          title: 'Yes/No field',
+          options: {}
+        },
+        {
+          id: 'c5f73f1e-e15c-4558-afe9-63e8ca15ac35',
+          type: ComponentType.EmailAddressField,
+          name: 'emailAddressField',
+          title: 'Email address field',
+          options: {}
+        },
+        {
+          id: '14875380-b27c-4119-829b-68f4aa427fca',
+          type: ComponentType.TelephoneNumberField,
+          name: 'telephoneNumberField',
+          title: 'Telephone number field',
+          options: {}
+        },
+        {
+          id: '12ad0026-e0ac-4081-850a-a8eede6a5a8a',
+          type: ComponentType.UkAddressField,
+          name: 'addressField',
+          title: 'Address field',
+          options: {}
+        },
+        {
+          id: '7817fa20-8791-40f7-a5f9-44593a4e44dc',
+          type: ComponentType.RadiosField,
+          name: 'radiosField',
+          title: 'Radios field',
+          list: 'companyType',
+          options: {}
+        },
+        {
+          id: '8a6a413f-28ca-464c-8cf8-09c54fbb68d8',
+          type: ComponentType.SelectField,
+          name: 'selectField',
+          title: 'Select field',
+          list: 'country',
+          options: {}
+        },
+        {
+          id: '7b7683c3-65b3-4640-90aa-63b82a9d4011',
+          type: ComponentType.AutocompleteField,
+          name: 'autocompleteField',
+          title: 'Autocomplete field',
+          list: 'country',
+          options: {}
+        },
+        {
+          id: 'e6fd3926-d294-45b6-be7e-a2d55c9f8a22',
+          list: 'horseBreed',
+          type: ComponentType.CheckboxesField,
+          name: 'checkboxesSingle',
+          title: 'Checkboxes field 1',
+          hint: 'Select all that apply.',
+          options: {}
+        },
+        {
+          id: 'ace90ac8-00d8-4fbc-be0e-cbe02ac34b82',
+          list: 'horseBreed',
+          type: ComponentType.CheckboxesField,
+          name: 'checkboxesMultiple',
+          title: 'Checkboxes field 2',
+          hint: 'Select all that apply.',
+          options: {}
+        },
+        {
+          id: '4a35371d-7d29-479c-af36-5d946f5f9f6a',
+          list: 'points',
+          type: ComponentType.CheckboxesField,
+          name: 'checkboxesSingleNumber',
+          title: 'Checkboxes field 3 (number)',
+          hint: 'Select all that apply.',
+          options: {}
+        },
+        {
+          id: 'eed182fa-7438-4056-9c1d-6f841f3088d2',
+          list: 'points',
+          type: ComponentType.CheckboxesField,
+          name: 'checkboxesMultipleNumber',
+          title: 'Checkboxes field at least 2 items',
+          hint: 'Select all that apply.',
+          options: {},
+          schema: {
+            min: 2
+          }
+        },
+        {
+          id: '0f868ea2-119a-4b2f-8230-0e688a22a48d',
+          type: ComponentType.EastingNorthingField,
+          name: 'eastingNorthing',
+          title: 'Easting northing field',
+          options: {}
+        },
+        {
+          id: 'ae9993c8-68b6-4f4e-b581-7bd545a0117a',
+          type: ComponentType.GeospatialField,
+          name: 'geospatial',
+          title: 'Geospatial field',
+          options: {
+            countries: ['england']
+          }
+        },
+        {
+          id: 'd7bfe70f-63d8-4407-83b7-14ab28ea25cd',
+          type: ComponentType.LatLongField,
+          name: 'latLong',
+          title: 'LatLong field',
+          options: {}
+        },
+        {
+          id: '288afb69-6e33-4a03-a11c-bf7a8ee44f0d',
+          type: ComponentType.NationalGridFieldNumberField,
+          name: 'nationalGrid',
+          title: 'National Grid field',
+          options: {}
+        },
+        {
+          id: '1ad26d80-db7d-496d-9fcc-7c93fb9bf7e1',
+          type: ComponentType.OsGridRefField,
+          name: 'osGrid',
+          title: 'OS Grid field',
+          options: {}
+        },
+        {
+          id: '9336089e-dc36-473f-9aee-1cf919919fe1',
+          type: ComponentType.DeclarationField,
+          name: 'declaration',
+          title: 'Declaration',
+          content:
+            'By submitting this form, I agree to:\n\n- Provide accurate and complete information\n- Comply with all applicable regulations\n- Accept responsibility for any false statements',
+          hint: 'Please read and confirm the following terms',
+          options: {}
+        }
+      ],
+      next: [
+        {
+          path: '/summary'
+        }
+      ]
+    },
+    {
+      path: ControllerPath.Summary,
+      controller: ControllerType.Summary,
+      title: 'Summary'
+    }
+  ]),
+  lists: [
+    {
+      name: 'companyType',
+      title: 'Company type',
+      type: 'string',
+      items: [
+        { text: 'Sole trader', value: 'soleTrader' },
+        { text: 'Private Limited Company', value: 'privateLimitedCompany' },
+        { text: 'Public Limited Company', value: 'publicLimitedCompany' },
+        {
+          text: 'Limited Liability Partnership',
+          value: 'limitedLiabilityPartnership'
+        },
+        { text: 'Charity', value: 'charity' },
+        { text: 'Other', value: 'other' }
+      ]
+    },
+    {
+      name: 'country',
+      title: 'Country',
+      type: 'number',
+      items: [
+        { text: 'Afghanistan', value: 910400000 },
+        { text: 'Albania', value: 910400001 },
+        { text: 'Algeria', value: 910400002 },
+        { text: 'Andorra', value: 910400003 },
+        { text: 'Angola', value: 910400004 },
+        { text: 'Antigua and Barbuda', value: 910400005 },
+        { text: 'Argentina', value: 910400006 },
+        { text: 'Armenia', value: 910400007 },
+        { text: 'Australia', value: 910400008 },
+        { text: 'Austria', value: 910400009 },
+        { text: 'Azerbaijan', value: 910400010 },
+        { text: 'Bahrain', value: 910400011 },
+        { text: 'Bangladesh', value: 910400012 },
+        { text: 'Barbados', value: 910400013 },
+        { text: 'Belarus', value: 910400014 },
+        { text: 'Belgium', value: 910400015 },
+        { text: 'Belize', value: 910400016 },
+        { text: 'Benin', value: 910400017 },
+        { text: 'Bhutan', value: 910400018 },
+        { text: 'Bolivia', value: 910400019 },
+        { text: 'Bosnia and Herzegovina', value: 910400020 },
+        { text: 'Botswana', value: 910400021 },
+        { text: 'Brazil', value: 910400022 },
+        { text: 'Brunei', value: 910400023 },
+        { text: 'Bulgaria', value: 910400024 },
+        { text: 'Burkina Faso', value: 910400025 },
+        { text: 'Burma', value: 910400026 },
+        { text: 'Burundi', value: 910400027 },
+        { text: 'Cambodia', value: 910400028 },
+        { text: 'Cameroon', value: 910400029 },
+        { text: 'Canada', value: 910400030 },
+        { text: 'Cape Verde', value: 910400031 },
+        { text: 'Central African Republic', value: 910400032 },
+        { text: 'Chad', value: 910400033 },
+        { text: 'Chile', value: 910400034 },
+        { text: 'China', value: 910400035 },
+        { text: 'Colombia', value: 910400036 },
+        { text: 'Comoros', value: 910400037 },
+        { text: 'Congo', value: 910400038 },
+        { text: 'Congo (Democratic Republic)', value: 910400039 },
+        { text: 'Costa Rica', value: 910400040 },
+        { text: 'Croatia', value: 910400041 },
+        { text: 'Cuba', value: 910400042 },
+        { text: 'Cyprus', value: 910400043 },
+        { text: 'Czech Republic', value: 910400044 },
+        { text: 'Denmark', value: 910400045 },
+        { text: 'Djibouti', value: 910400046 },
+        { text: 'Dominica', value: 910400047 },
+        { text: 'Dominican Republic', value: 910400048 },
+        { text: 'East Timor', value: 910400049 },
+        { text: 'Ecuador', value: 910400050 },
+        { text: 'Egypt', value: 910400051 },
+        { text: 'El Salvador', value: 910400052 },
+        { text: 'Equatorial Guinea', value: 910400053 },
+        { text: 'Eritrea', value: 910400054 },
+        { text: 'Estonia', value: 910400055 },
+        { text: 'Ethiopia', value: 910400056 },
+        { text: 'Fiji', value: 910400057 },
+        { text: 'Finland', value: 910400058 },
+        { text: 'France', value: 910400059 },
+        { text: 'Gabon', value: 910400060 },
+        { text: 'Georgia', value: 910400061 },
+        { text: 'Germany', value: 910400062 },
+        { text: 'Ghana', value: 910400063 },
+        { text: 'Greece', value: 910400064 },
+        { text: 'Grenada', value: 910400065 },
+        { text: 'Guatemala', value: 910400066 },
+        { text: 'Guinea', value: 910400067 },
+        { text: 'Guinea-Bissau', value: 910400068 },
+        { text: 'Guyana', value: 910400069 },
+        { text: 'Haiti', value: 910400070 },
+        { text: 'Honduras', value: 910400071 },
+        { text: 'Hungary', value: 910400072 },
+        { text: 'Iceland', value: 910400073 },
+        { text: 'India', value: 910400074 },
+        { text: 'Indonesia', value: 910400075 },
+        { text: 'Iran', value: 910400076 },
+        { text: 'Iraq', value: 910400077 },
+        { text: 'Ireland', value: 910400078 },
+        { text: 'Israel', value: 910400079 },
+        { text: 'Italy', value: 910400080 },
+        { text: 'Ivory Coast', value: 910400081 },
+        { text: 'Jamaica', value: 910400082 },
+        { text: 'Japan', value: 910400083 },
+        { text: 'Jordan', value: 910400084 },
+        { text: 'Kazakhstan', value: 910400085 },
+        { text: 'Kenya', value: 910400086 },
+        { text: 'Kiribati', value: 910400087 },
+        { text: 'Kosovo', value: 910400088 },
+        { text: 'Kuwait', value: 910400089 },
+        { text: 'Kyrgyzstan', value: 910400090 },
+        { text: 'Laos', value: 910400091 },
+        { text: 'Latvia', value: 910400092 },
+        { text: 'Lebanon', value: 910400093 },
+        { text: 'Lesotho', value: 910400094 },
+        { text: 'Liberia', value: 910400095 },
+        { text: 'Libya', value: 910400096 },
+        { text: 'Liechtenstein', value: 910400097 },
+        { text: 'Lithuania', value: 910400098 },
+        { text: 'Luxembourg', value: 910400099 },
+        { text: 'Macedonia', value: 910400100 },
+        { text: 'Madagascar', value: 910400101 },
+        { text: 'Malawi', value: 910400102 },
+        { text: 'Malaysia', value: 910400103 },
+        { text: 'Maldives', value: 910400104 },
+        { text: 'Mali', value: 910400105 },
+        { text: 'Malta', value: 910400106 },
+        { text: 'Marshall Islands', value: 910400107 },
+        { text: 'Mauritania', value: 910400108 },
+        { text: 'Mauritius', value: 910400109 },
+        { text: 'Mexico', value: 910400110 },
+        { text: 'Micronesia', value: 910400111 },
+        { text: 'Moldova', value: 910400112 },
+        { text: 'Monaco', value: 910400113 },
+        { text: 'Mongolia', value: 910400114 },
+        { text: 'Montenegro', value: 910400115 },
+        { text: 'Morocco', value: 910400116 },
+        { text: 'Mozambique', value: 910400117 },
+        { text: 'Namibia', value: 910400118 },
+        { text: 'Nauru', value: 910400119 },
+        { text: 'Nepal', value: 910400120 },
+        { text: 'Netherlands', value: 910400121 },
+        { text: 'New Zealand', value: 910400122 },
+        { text: 'Nicaragua', value: 910400123 },
+        { text: 'Niger', value: 910400124 },
+        { text: 'Nigeria', value: 910400125 },
+        { text: 'North Korea', value: 910400126 },
+        { text: 'Norway', value: 910400127 },
+        { text: 'Oman', value: 910400128 },
+        { text: 'Pakistan', value: 910400129 },
+        { text: 'Palau', value: 910400130 },
+        { text: 'Panama', value: 910400131 },
+        { text: 'Papua New Guinea', value: 910400132 },
+        { text: 'Paraguay', value: 910400133 },
+        { text: 'Peru', value: 910400134 },
+        { text: 'Philippines', value: 910400135 },
+        { text: 'Poland', value: 910400136 },
+        { text: 'Portugal', value: 910400137 },
+        { text: 'Qatar', value: 910400138 },
+        { text: 'Romania', value: 910400139 },
+        { text: 'Russia', value: 910400140 },
+        { text: 'Rwanda', value: 910400141 },
+        { text: 'Samoa', value: 910400142 },
+        { text: 'San Marino', value: 910400143 },
+        { text: 'Sao Tome and Principe', value: 910400144 },
+        { text: 'Saudi Arabia', value: 910400145 },
+        { text: 'Senegal', value: 910400146 },
+        { text: 'Serbia', value: 910400147 },
+        { text: 'Seychelles', value: 910400148 },
+        { text: 'Sierra Leone', value: 910400149 },
+        { text: 'Singapore', value: 910400150 },
+        { text: 'Slovakia', value: 910400151 },
+        { text: 'Slovenia', value: 910400152 },
+        { text: 'Solomon Islands', value: 910400153 },
+        { text: 'Somalia', value: 910400154 },
+        { text: 'South Africa', value: 910400155 },
+        { text: 'South Korea', value: 910400156 },
+        { text: 'South Sudan', value: 910400157 },
+        { text: 'Spain', value: 910400158 },
+        { text: 'Sri Lanka', value: 910400159 },
+        { text: 'St Kitts and Nevis', value: 910400160 },
+        { text: 'St Lucia', value: 910400161 },
+        { text: 'St Vincent', value: 910400162 },
+        { text: 'Sudan', value: 910400163 },
+        { text: 'Suriname', value: 910400164 },
+        { text: 'Swaziland', value: 910400165 },
+        { text: 'Sweden', value: 910400166 },
+        { text: 'Switzerland', value: 910400167 },
+        { text: 'Syria', value: 910400168 },
+        { text: 'Tajikistan', value: 910400169 },
+        { text: 'Tanzania', value: 910400170 },
+        { text: 'Thailand', value: 910400171 },
+        { text: 'The Bahamas', value: 910400172 },
+        { text: 'The Gambia', value: 910400173 },
+        { text: 'Togo', value: 910400174 },
+        { text: 'Tonga', value: 910400175 },
+        { text: 'Trinidad and Tobago', value: 910400176 },
+        { text: 'Tunisia', value: 910400177 },
+        { text: 'Turkey', value: 910400178 },
+        { text: 'Turkmenistan', value: 910400179 },
+        { text: 'Tuvalu', value: 910400180 },
+        { text: 'Uganda', value: 910400181 },
+        { text: 'Ukraine', value: 910400182 },
+        { text: 'United Arab Emirates', value: 910400183 },
+        { text: 'United Kingdom', value: 910400184 },
+        { text: 'United States', value: 910400185 },
+        { text: 'Uruguay', value: 910400186 },
+        { text: 'Uzbekistan', value: 910400187 },
+        { text: 'Vanuatu', value: 910400188 },
+        { text: 'Vatican City', value: 910400189 },
+        { text: 'Venezuela', value: 910400190 },
+        { text: 'Vietnam', value: 910400191 },
+        { text: 'Yemen', value: 910400192 },
+        { text: 'Zambia', value: 910400193 },
+        { text: 'Zimbabwe', value: 910400194 },
+        { text: 'England', value: 910400195 },
+        { text: 'Wales', value: 910400196 },
+        { text: 'Scotland', value: 910400197 },
+        { text: 'Northern Ireland', value: 910400198 }
+      ]
+    },
+    {
+      name: 'horseBreed',
+      title: 'Horse breed',
+      type: 'string',
+      items: [
+        { text: 'Arabian', value: 'Arabian' },
+        { text: 'Patomine', value: 'Patomine' },
+        { text: 'Shire', value: 'Shire' },
+        { text: 'Shetland', value: 'Shetland' },
+        { text: 'Race', value: 'Race' }
+      ]
+    },
+    {
+      name: 'points',
+      title: 'Number of points',
+      type: 'number',
+      items: [
+        { text: 'None', value: 0 },
+        { text: '1 point', value: 1 },
+        { text: '2 points', value: 2 },
+        { text: '3 points', value: 3 },
+        { text: '4 points', value: 4 }
+      ]
+    }
+  ],
+  sections: [],
+  conditions: [],
+  metadata: {
+    translations: {
+      cy: {
+        'form.title': 'Welsh fields required',
+        'pages.4af89edc-2424-4fed-937c-500525667b96.title':
+          'Welsh fields required translated',
+        'components.f4c68ce0-d868-43cb-87df-b80018dec23a.title':
+          'Welsh Text field',
+        'components.f4c68ce0-d868-43cb-87df-b80018dec23a.shortDescription':
+          'Welsh textfield short desc',
+        'components.f4c68ce0-d868-43cb-87df-b80018dec23a.errorDescription':
+          'Welsh textfield error desc',
+        'components.9d83327b-3783-430c-aef8-c73875672cae.title':
+          'Welsh Multiline text field',
+        'components.33bd0fbe-52d2-4fb4-94d1-b036747a9d38.title':
+          'Welsh Number field',
+        'components.03d0d43f-4dbb-4c52-9291-be63c4636748.title':
+          'Welsh Date parts field',
+        'components.ba70dabf-ea01-4643-808c-24638743fcf7.title':
+          'Welsh Month year field',
+        'components.7d4660a1-2e5b-48d7-854d-3bb1fe75c2c3.title':
+          'Welsh Yes/No field',
+        'components.c5f73f1e-e15c-4558-afe9-63e8ca15ac35.title':
+          'Welsh Email address field',
+        'components.14875380-b27c-4119-829b-68f4aa427fca.title':
+          'Welsh Telephone number field',
+        'components.12ad0026-e0ac-4081-850a-a8eede6a5a8a.title':
+          'Welsh Address field',
+        'components.7817fa20-8791-40f7-a5f9-44593a4e44dc.title':
+          'Welsh Radios field',
+        'components.8a6a413f-28ca-464c-8cf8-09c54fbb68d8.title':
+          'Welsh Select field',
+        'components.7b7683c3-65b3-4640-90aa-63b82a9d4011.title':
+          'Welsh Autocomplete field',
+        'components.e6fd3926-d294-45b6-be7e-a2d55c9f8a22.title':
+          'Welsh Checkboxes field 1',
+        'components.ace90ac8-00d8-4fbc-be0e-cbe02ac34b82.title':
+          'Welsh Checkboxes field 2',
+        'components.4a35371d-7d29-479c-af36-5d946f5f9f6a.title':
+          'Welsh Checkboxes field 3 (number)',
+        'components.eed182fa-7438-4056-9c1d-6f841f3088d2.title':
+          'Welsh Checkboxes field at least 2 items',
+        'components.0f868ea2-119a-4b2f-8230-0e688a22a48d.title':
+          'Welsh EastingNorthing field',
+        'components.ae9993c8-68b6-4f4e-b581-7bd545a0117a.title':
+          'Welsh Geospatial field',
+        'components.d7bfe70f-63d8-4407-83b7-14ab28ea25cd.title':
+          'Welsh LatLong field',
+        'components.288afb69-6e33-4a03-a11c-bf7a8ee44f0d.title':
+          'Welsh National Grid field',
+        'components.1ad26d80-db7d-496d-9fcc-7c93fb9bf7e1.title':
+          'Welsh OS Grid field',
+        'components.9336089e-dc36-473f-9aee-1cf919919fe1.title':
+          'Welsh Declaration'
+      }
+    }
+  }
+})
+
+/**
+ * @import { FormDefinition } from '@defra/forms-model'
+ */

--- a/test/form/fields-required-translated.test.js
+++ b/test/form/fields-required-translated.test.js
@@ -1,0 +1,651 @@
+import { join } from 'node:path'
+
+import { within } from '@testing-library/dom'
+import { StatusCodes } from 'http-status-codes'
+
+import { FORM_PREFIX } from '~/src/server/constants.js'
+import { createServer } from '~/src/server/index.js'
+import { getFormMetadata } from '~/src/server/plugins/engine/services/formsService.js'
+import * as fixtures from '~/test/fixtures/index.js'
+import { renderResponse } from '~/test/helpers/component-helpers.js'
+import { getCookie, getCookieHeader } from '~/test/utils/get-cookie.js'
+
+const basePath = `${FORM_PREFIX}/fields-required-translated`
+
+jest.mock('~/src/server/plugins/engine/services/formsService.js')
+
+describe('Form fields (required)', () => {
+  const journey = [
+    {
+      heading1: 'Welsh fields required translated',
+
+      paths: {
+        current: '/components',
+        next: '/summary'
+      },
+
+      fields: [
+        {
+          name: 'textField',
+          title: 'Text field',
+          payload: {
+            empty: { textField: '' },
+            invalid: { textField: 'This text is too long for the field' },
+            valid: { textField: 'Example text field' }
+          }
+        },
+        {
+          title: 'Multiline text field',
+          value: 'Example multiline text field',
+          payload: {
+            empty: { multilineTextField: '' },
+            invalid: {
+              multilineTextField: 'This text is too long for the field'
+            },
+            valid: { multilineTextField: 'Example multiline text field' }
+          }
+        },
+        {
+          title: 'Number field',
+          payload: {
+            empty: { numberField: '' },
+            invalid: { numberField: '123456' },
+            valid: { numberField: '1234' }
+          }
+        },
+        {
+          name: 'datePartsField',
+          title: 'Date parts field',
+          payload: {
+            empty: {
+              datePartsField__day: '',
+              datePartsField__month: '',
+              datePartsField__year: ''
+            },
+            invalid: {
+              datePartsField__day: '32',
+              datePartsField__month: '13',
+              datePartsField__year: '3100'
+            },
+            valid: {
+              datePartsField__day: '31',
+              datePartsField__month: '12',
+              datePartsField__year: '2021'
+            }
+          }
+        },
+        {
+          name: 'monthYearField',
+          title: 'Month year field',
+          payload: {
+            empty: {
+              monthYearField__month: '',
+              monthYearField__year: ''
+            },
+            invalid: {
+              monthYearField__month: '13',
+              monthYearField__year: '2021'
+            },
+            valid: {
+              monthYearField__month: '12',
+              monthYearField__year: '2021'
+            }
+          }
+        },
+        {
+          name: 'yesNoField',
+          title: 'Yes/No field',
+          payload: {
+            empty: {},
+            invalid: {},
+            valid: { yesNoField: 'true' }
+          }
+        },
+        {
+          name: 'emailAddressField',
+          title: 'Email address field',
+          payload: {
+            empty: { emailAddressField: '' },
+            invalid: { emailAddressField: 'defra.helpline' },
+            invalid2: { emailAddressField: 'defra–helpline@endash.com' },
+            valid: { emailAddressField: 'defra.helpline@defra.gov.uk' }
+          }
+        },
+        {
+          name: 'telephoneNumberField',
+          title: 'Telephone number field',
+          payload: {
+            empty: { telephoneNumberField: '' },
+            invalid: { telephoneNumberField: '44790000' },
+            valid: { telephoneNumberField: '+447900000000' }
+          }
+        },
+        {
+          name: 'addressField',
+          title: 'Address field',
+          payload: {
+            empty: {
+              addressField__addressLine1: '',
+              addressField__addressLine2: '',
+              addressField__town: '',
+              addressField__county: '',
+              addressField__postcode: '',
+              addressField__uprn: ''
+            },
+            invalid: {
+              addressField__addressLine1: 'Richard Fairclough House',
+              addressField__addressLine2: '',
+              addressField__town: 'Warrington',
+              addressField__county: '',
+              addressField__postcode: 'ABC',
+              addressField__uprn: ''
+            },
+            valid: {
+              addressField__addressLine1: 'Richard Fairclough House',
+              addressField__addressLine2: 'Knutsford Road',
+              addressField__town: 'Warrington',
+              addressField__county: 'Cheshire',
+              addressField__postcode: 'WA4 1HT',
+              addressField__uprn: ''
+            }
+          }
+        },
+        {
+          name: 'radiosField',
+          title: 'Radios field',
+          payload: {
+            empty: {},
+            invalid: {},
+            valid: { radiosField: 'privateLimitedCompany' }
+          }
+        },
+        {
+          name: 'selectField',
+          title: 'Select field',
+          payload: {
+            empty: { selectField: '' },
+            invalid: { selectField: '' },
+            valid: { selectField: '910400158' }
+          }
+        },
+        {
+          name: 'autocompleteField',
+          title: 'Autocomplete field',
+          payload: {
+            empty: { autocompleteField: '' },
+            invalid: { autocompleteField: '' },
+            valid: { autocompleteField: '910400184' }
+          }
+        },
+        {
+          name: 'checkboxesSingle',
+          title: 'Checkboxes field 1',
+          payload: {
+            empty: {},
+            invalid: {},
+            valid: { checkboxesSingle: 'Arabian' }
+          }
+        },
+        {
+          name: 'checkboxesMultiple',
+          title: 'Checkboxes field 2',
+          payload: {
+            empty: {},
+            invalid: {},
+            valid: { checkboxesMultiple: 'Patomine' }
+          }
+        },
+        {
+          name: 'checkboxesSingleNumber',
+          title: 'Checkboxes field 3 (number)',
+          payload: {
+            empty: {},
+            invalid: {},
+            valid: { checkboxesSingleNumber: '0' }
+          }
+        },
+        {
+          name: 'checkboxesMultipleNumber',
+          title: 'Checkboxes field at least 2 items',
+          payload: {
+            empty: {},
+            invalid: {},
+            invalid2: { checkboxesMultipleNumber: ['1'] },
+            valid: { checkboxesMultipleNumber: ['1', '2'] }
+          }
+        },
+        {
+          name: 'eastingNorthing',
+          title: 'EastingNorthing field',
+          payload: {
+            empty: {
+              eastingNorthing__easting: '',
+              eastingNorthing__northing: ''
+            },
+            invalid: {
+              eastingNorthing__easting: '111111111',
+              eastingNorthing__northing: '222222222'
+            },
+            valid: {
+              eastingNorthing__easting: '1',
+              eastingNorthing__northing: '1'
+            }
+          }
+        },
+        {
+          name: 'geospatial',
+          title: 'Geospatial field',
+          payload: {
+            empty: { geospatial: '' },
+            invalid: {
+              geospatial: `[
+                {
+                  "type": "Feature",
+                  "properties": {
+                    "description": "",
+                    "coordinateGridReference": "SD 66261 97639",
+                    "centroidGridReference": "SD 66261 97639"
+                  },
+                  "geometry": {
+                    "type": "Point",
+                    "coordinates": [
+                      -2.520852,
+                      54.3731392
+                    ]
+                  },
+                  "id": "cad71663-7b1e-4b02-83f0-ae1cd7fa24f4"
+                }
+              ]`
+            },
+            invalid2: {
+              geospatial: `[
+                {
+                  "type": "Feature",
+                  "properties": {
+                    "description": "p2",
+                    "coordinateGridReference": "SD 66261 97639",
+                    "centroidGridReference": "SD 66261 97639"
+                  },
+                  "geometry": {
+                    "type": "Point",
+                    "coordinates": [
+                      -3.9161157,
+                      55.533858
+                    ]
+                  },
+                  "id": "cad71663-7b1e-4b02-83f0-ae1cd7fa24f4"
+                }
+              ]`
+            },
+            valid: {
+              geospatial: `[
+                {
+                  "type": "Feature",
+                  "properties": {
+                    "description": "p1",
+                    "coordinateGridReference": "SD 66261 97639",
+                    "centroidGridReference": "SD 66261 97639"
+                  },
+                  "geometry": {
+                    "type": "Point",
+                    "coordinates": [
+                      -2.520852,
+                      54.3731392
+                    ]
+                  },
+                  "id": "cad71663-7b1e-4b02-83f0-ae1cd7fa24f4"
+                }
+              ]`
+            }
+          }
+        },
+        {
+          name: 'latLong',
+          title: 'LatLong field',
+          payload: {
+            empty: { latLong__latitude: '', latLong__longitude: '' },
+            invalid: {
+              latLong__latitude: '11111111',
+              latLong__longitude: '2222222'
+            },
+            valid: { latLong__latitude: '50', latLong__longitude: '1.5' }
+          }
+        },
+        {
+          name: 'nationalGrid',
+          title: 'National Grid field',
+          payload: {
+            empty: {},
+            invalid: { nationalGrid: 'ABC' },
+            valid: { nationalGrid: 'NG 1234 5678' }
+          }
+        },
+        {
+          name: 'osGrid',
+          title: 'OS Grid field',
+          payload: {
+            empty: {},
+            invalid: { osGrid: 'ABC' },
+            valid: { osGrid: 'TQ123456' }
+          }
+        },
+        {
+          name: 'declaration',
+          title: 'Declaration',
+          payload: {
+            empty: { declaration: 'unchecked' },
+            invalid: { declaration: 'unchecked' },
+            valid: { declaration: 'true' }
+          }
+        }
+      ]
+    }
+  ]
+
+  /** @type {Server} */
+  let server
+
+  /** @type {string} */
+  let csrfToken
+
+  /** @type {ReturnType<typeof getCookieHeader>} */
+  let headers
+
+  /** @type {BoundFunctions<typeof queries>} */
+  let container
+
+  // Create server before each test
+  beforeAll(async () => {
+    server = await createServer({
+      formFileName: 'fields-required-translated.js',
+      formFilePath: join(import.meta.dirname, 'definitions'),
+      enforceCsrf: true
+    })
+
+    await server.initialize()
+
+    // Navigate to start
+    const response = await server.inject({
+      url: `${basePath}${journey[0].paths.current}?language=cy`
+    })
+
+    // Extract the session cookie
+    csrfToken = getCookie(response, 'crumb')
+    headers = getCookieHeader(response, ['session', 'crumb'])
+  })
+
+  beforeEach(() => {
+    jest.mocked(getFormMetadata).mockResolvedValue(fixtures.form.metadata)
+  })
+
+  afterAll(async () => {
+    await server.stop()
+  })
+
+  describe.each(journey)(
+    'Page: $paths.current',
+    ({ heading1, paths, fields = [] }) => {
+      beforeEach(async () => {
+        ;({ container } = await renderResponse(server, {
+          url: `${basePath}${paths.current}`,
+          headers
+        }))
+      })
+
+      it('should render the page heading', () => {
+        const $heading = container.getByRole('heading', {
+          name: heading1,
+          level: 1
+        })
+
+        expect($heading).toBeInTheDocument()
+      })
+
+      it('should render the field label without (optional)', () => {
+        for (const field of fields) {
+          const $label = container.getByText(`Welsh ${field.title}`)
+          expect($label).toBeInTheDocument()
+        }
+      })
+
+      it('should show errors when fields empty on submit', async () => {
+        const payload = {}
+
+        for (const field of fields) {
+          Object.assign(payload, field.payload.empty)
+        }
+
+        // Submit form with empty values
+        const { container, response } = await renderResponse(server, {
+          url: `${basePath}${paths.current}`,
+          method: 'POST',
+          headers,
+          payload: { ...payload, crumb: csrfToken }
+        })
+
+        expect(response.statusCode).toBe(StatusCodes.OK)
+        expect(response.headers.location).toBeUndefined()
+
+        const $errorSummary = container.getByRole('alert')
+
+        const $heading = within($errorSummary).getByRole('heading', {
+          name: 'Mae problem',
+          level: 2
+        })
+
+        expect($heading).toBeInTheDocument()
+
+        const $errors = $errorSummary.querySelectorAll('a')
+        expect($errors).toHaveLength(26)
+        expect($errors[0].textContent).toBe('Nodwch welsh textfield error desc')
+        expect($errors[1].textContent).toBe('Nodwch welsh Multiline text field')
+        expect($errors[2].textContent).toBe('Nodwch Welsh Number field')
+        expect($errors[3].textContent).toBe(
+          'Rhaid i Welsh Date parts field gynnwys diwrnod'
+        )
+        expect($errors[4].textContent).toBe(
+          'Rhaid i Welsh Month year field gynnwys mis'
+        )
+        expect($errors[5].textContent).toBe(
+          'Welsh Yes/No field - dewiswch ie neu nage'
+        )
+        expect($errors[6].textContent).toBe('Nodwch welsh Email address field')
+        expect($errors[7].textContent).toBe(
+          'Nodwch welsh Telephone number field'
+        )
+        expect($errors[8].textContent).toBe('Nodwch llinell cyfeiriad 1')
+        expect($errors[9].textContent).toBe('Nodwch tref neu ddinas')
+        expect($errors[10].textContent).toBe('Nodwch cod post')
+        expect($errors[11].textContent).toBe('Dewiswch welsh Radios field')
+        expect($errors[12].textContent).toBe('Dewiswch welsh Select field')
+        expect($errors[13].textContent).toBe('Nodwch Welsh Autocomplete field')
+        expect($errors[14].textContent).toBe(
+          'Dewiswch welsh Checkboxes field 1'
+        )
+        expect($errors[15].textContent).toBe(
+          'Dewiswch welsh Checkboxes field 2'
+        )
+        expect($errors[16].textContent).toBe(
+          'Dewiswch welsh Checkboxes field 3 (number)'
+        )
+        expect($errors[17].textContent).toBe(
+          'Dewiswch welsh Checkboxes field at least 2 items'
+        )
+        expect($errors[18].textContent).toBe('Nodwch ddwyreiniannau')
+        expect($errors[19].textContent).toBe('Nodwch ogleddiannau')
+        expect($errors[20].textContent).toBe('Dewiswch welsh Geospatial field')
+        expect($errors[21].textContent).toBe('Nodwch ledred')
+        expect($errors[22].textContent).toBe('Nodwch hydred')
+        expect($errors[23].textContent).toBe('Nodwch welsh National Grid field')
+        expect($errors[24].textContent).toBe('Nodwch welsh OS Grid field')
+        expect($errors[25].textContent).toBe(
+          "Rhaid i chi gadarnhau eich bod yn deall ac yn cytuno â'r welsh Declaration i barhau"
+        )
+      })
+
+      it('should show errors when fields invalid value on submit - scenario 1', async () => {
+        const payload = {}
+
+        for (const field of fields) {
+          Object.assign(payload, field.payload.invalid)
+        }
+
+        // Submit form with empty values
+        const { container, response } = await renderResponse(server, {
+          url: `${basePath}${paths.current}`,
+          method: 'POST',
+          headers,
+          payload: { ...payload, crumb: csrfToken }
+        })
+
+        expect(response.statusCode).toBe(StatusCodes.OK)
+        expect(response.headers.location).toBeUndefined()
+
+        const $errorSummary = container.getByRole('alert')
+
+        const $heading = within($errorSummary).getByRole('heading', {
+          name: 'Mae problem',
+          level: 2
+        })
+
+        expect($heading).toBeInTheDocument()
+
+        const $errors = $errorSummary.querySelectorAll('a')
+        expect($errors).toHaveLength(24)
+        expect($errors[0].textContent).toBe(
+          'Rhaid i Welsh textfield error desc fod yn 30 o nodau neu lai'
+        )
+        expect($errors[1].textContent).toBe(
+          'Rhaid i Welsh Multiline text field fod yn 30 o nodau neu lai'
+        )
+        expect($errors[2].textContent).toBe(
+          'Rhaid i Welsh Number field fod yn 2000 neu is'
+        )
+        expect($errors[3].textContent).toBe(
+          'Rhaid i Welsh Date parts field fod yn ddyddiad go iawn'
+        )
+        expect($errors[4].textContent).toBe(
+          'Rhaid i Welsh Month year field fod yn ddyddiad go iawn'
+        )
+        expect($errors[5].textContent).toBe(
+          'Welsh Yes/No field - dewiswch ie neu nage'
+        )
+        expect($errors[6].textContent).toBe(
+          'Nodwch welsh Email address field yn y fformat cywir'
+        )
+        expect($errors[7].textContent).toBe(
+          'Nodwch welsh Telephone number field yn y fformat cywir'
+        )
+        expect($errors[8].textContent).toBe('Nodwch cod post dilys')
+        expect($errors[9].textContent).toBe('Dewiswch welsh Radios field')
+        expect($errors[10].textContent).toBe('Dewiswch welsh Select field')
+        expect($errors[11].textContent).toBe('Nodwch Welsh Autocomplete field')
+        expect($errors[12].textContent).toBe(
+          'Dewiswch welsh Checkboxes field 1'
+        )
+        expect($errors[13].textContent).toBe(
+          'Dewiswch welsh Checkboxes field 2'
+        )
+        expect($errors[14].textContent).toBe(
+          'Dewiswch welsh Checkboxes field 3 (number)'
+        )
+        expect($errors[15].textContent).toBe(
+          'Dewiswch welsh Checkboxes field at least 2 items'
+        )
+        expect($errors[16].textContent).toBe(
+          'Rhaid i Dwyreiniannau ar gyfer welsh EastingNorthing field fod rhwng 0 a 700000'
+        )
+        expect($errors[17].textContent).toBe(
+          'Rhaid i Gogleddiannau ar gyfer welsh EastingNorthing field fod rhwng 0 a 1300000'
+        )
+        expect($errors[18].textContent).toBe(
+          'Rhowch ddisgrifiad ar gyfer lleoliad 1'
+        )
+        expect($errors[19].textContent).toBe(
+          'Rhaid i ledred welsh LatLong field fod rhwng 49.85 a 60.859'
+        )
+        expect($errors[20].textContent).toBe(
+          'Rhaid i hydred welsh LatLong field fod rhwng -13.687 a 1.767'
+        )
+        expect($errors[21].textContent).toBe(
+          'Nodwch rif maes Grid Cenedlaethol dilys ar gyfer welsh National Grid field fel NG 1234 5678'
+        )
+        expect($errors[22].textContent).toBe(
+          'Nodwch gyfeirnod grid AO dilys ar gyfer welsh OS Grid field fel TQ123456'
+        )
+        expect($errors[23].textContent).toBe(
+          "Rhaid i chi gadarnhau eich bod yn deall ac yn cytuno â'r welsh Declaration i barhau"
+        )
+      })
+
+      // For additional error conditions
+      // Leave remaining payload alone and only test specific components that have an 'invalid2' property
+      it('should show errors when fields invalid value on submit - scenario 2', async () => {
+        const payload = {}
+
+        for (const field of fields) {
+          Object.assign(
+            payload,
+            field.payload.invalid2 ?? field.payload.invalid
+          )
+        }
+
+        // Submit form with empty values
+        const { container, response } = await renderResponse(server, {
+          url: `${basePath}${paths.current}`,
+          method: 'POST',
+          headers,
+          payload: { ...payload, crumb: csrfToken }
+        })
+
+        expect(response.statusCode).toBe(StatusCodes.OK)
+        expect(response.headers.location).toBeUndefined()
+
+        const $errorSummary = container.getByRole('alert')
+
+        const $heading = within($errorSummary).getByRole('heading', {
+          name: 'Mae problem',
+          level: 2
+        })
+
+        expect($heading).toBeInTheDocument()
+
+        const $errors = $errorSummary.querySelectorAll('a')
+        expect($errors).toHaveLength(24)
+        expect($errors[6].textContent).toBe(
+          'Mae Welsh Email address field yn cynnwys nodau annilys, er enghraifft, dashes hirion'
+        )
+        expect($errors[15].textContent).toBe(
+          "Dewiswch o leiaf 2 o opsiynau o'r rhestr"
+        )
+        expect($errors[18].textContent).toBe(
+          'Rhaid i leoliad 1 fod y tu mewn i Lloegr'
+        )
+      })
+
+      it('should redirect to the next page on submit', async () => {
+        const payload = {}
+
+        for (const field of fields) {
+          Object.assign(payload, field.payload.valid)
+        }
+
+        // Submit form with populated values
+        const response = await server.inject({
+          url: `${basePath}${paths.current}`,
+          method: 'POST',
+          headers,
+          payload: { ...payload, crumb: csrfToken }
+        })
+
+        expect(response.statusCode).toBe(StatusCodes.SEE_OTHER)
+        expect(response.headers.location).toBe(`${basePath}${paths.next}`)
+      })
+    }
+  )
+})
+
+/**
+ * @import { Server } from '@hapi/hapi'
+ * @import { BoundFunctions, queries } from '@testing-library/dom'
+ */

--- a/test/form/file-upload.test.js
+++ b/test/form/file-upload.test.js
@@ -229,18 +229,14 @@ describe('File upload POST tests', () => {
 
     expect($heading).toBeInTheDocument()
 
-    expect($errorItems[0]).toHaveTextContent(
-      'Upload your methodology statement must contain at least 2 items'
-    )
+    expect($errorItems[0]).toHaveTextContent('You must upload 2 files or more')
 
     const $input = container.getByLabelText(
       'Upload your methodology statement (optional)'
     )
 
     expect($input).toHaveAccessibleDescription(
-      expect.stringContaining(
-        'Error: Upload your methodology statement must contain at least 2 items'
-      )
+      expect.stringContaining('Error: You must upload 2 files or more')
     )
   })
 


### PR DESCRIPTION
<!--
  Thank you for contributing to DXT! Please follow the instructions in the comment tags.
  Unless you have been instructed, do not delete any text in this template.
-->

## Proposed change
A series of fixes, and full welsh translation unit tests for each component type.

1. Postcode lookup error - when no addresses were found - had two problems:
- the joining word should be 'and' (English) and not 'or' (English)
- the translation to Welsh of the adjoining words was not working
2. FileUpload hadn't been fully implemented for translations
3. OS Grid, National Grid, Autocomplete - all had the wrong message when field was empty
4. Date field + Month/year field - 'must include a' wasn't translated
5. Geospatial - if country restriction, 'country' was not being translated
6. Number field - there were problems with translating some of the range messages

Unit tests have been added to try to cover all components and all error messages - to prove Welsh translation occurs correctly.

<!--
  Give a high-level description of the content of this pull request. No more than a couple of sentences.

  If you have consulted with the Defra Forms team prior to implementation, they will have provided you with an Azure DevOps work item number or (preferably) a link. Please include this.
-->

Jira ticket: [DF-1069](https://eaflood.atlassian.net/browse/DF-1069)

## Type of change

<!--
  What type of change is this pull request? Mark the option with an X inside the brackets.
  If your change covers multiple categories, please split the pull request up to make it easier to review.
-->

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc. (documentation, build updates, etc)

## Checklist

<!--
  Mark each completed item with an X, e.g. "[X] You have....".
  Feel free to chat to us on Slack if you have any questions.

  If you have not completed all of this, you are welcome to submit your pull request in a draft state
  to give us visibility and gather early feedback until it is ready for review.
-->

- [X] You have executed this code locally and it performs as expected.
- [X] You have added tests to verify your code works.
- [X] You have added code comments and JSDoc, where appropriate.
- [X] There is no commented-out code.
- [X] You have added developer docs in `README.md` and `docs/*` (where appropriate, e.g. new features).
- [X] The tests are passing (`npm run test`).
- [X] The linting checks are passing (`npm run lint`).
- [X] The code has been formatted (`npm run format`).


[DF-1069]: https://eaflood.atlassian.net/browse/DF-1069?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ